### PR TITLE
feature: Added new step for Discord

### DIFF
--- a/src/components/CredentialsManager.tsx
+++ b/src/components/CredentialsManager.tsx
@@ -104,6 +104,12 @@ export function CredentialsManager() {
           { key: "accessToken", label: "Access Token", type: "password" },
           { key: "accessSecret", label: "Access Token Secret", type: "password" },
         ];
+      case "discord":
+        return [
+          { key: "botToken", label: "Bot Token", type: "password" },
+          { key: "clientId", label: "Client ID (optional)", type: "text" },
+          { key: "clientSecret", label: "Client Secret (optional)", type: "password" },
+        ];
       case "oauth":
         return [
           { key: "clientId", label: "Client ID", type: "text" },
@@ -159,6 +165,7 @@ export function CredentialsManager() {
               <SelectContent>
                 <SelectItem value="twitter">Twitter/X</SelectItem>
                 <SelectItem value="oauth">OAuth 2.0</SelectItem>
+                <SelectItem value="discord">Discord</SelectItem>
                 <SelectItem value="apiKey">API Key</SelectItem>
                 <SelectItem value="basic">Basic Auth</SelectItem>
                 <SelectItem value="custom">Custom</SelectItem>

--- a/src/components/automationBuilder/nodeDetails/StepEditor.tsx
+++ b/src/components/automationBuilder/nodeDetails/StepEditor.tsx
@@ -10,6 +10,12 @@ import { Label } from "@components/ui/label";
 import {
   ApiCallStep,
   ClickStep,
+  DiscordDeleteMessageStep,
+  DiscordGetMessageStep,
+  DiscordListMessagesStep,
+  DiscordReactStep,
+  DiscordSendMessageStep,
+  DiscordSendWebhookStep,
   ExtractStep,
   ModifyVariableStep,
   NavigateStep,
@@ -87,6 +93,18 @@ export default function StepEditor({
         );
       case "apiCall":
         return <ApiCallStep step={step} id={id} onUpdate={onUpdate} />;
+      case "discordSendMessage":
+        return <DiscordSendMessageStep step={step} id={id} onUpdate={onUpdate} />;
+      case "discordSendWebhook":
+        return <DiscordSendWebhookStep step={step} id={id} onUpdate={onUpdate} />;
+      case "discordReactMessage":
+        return <DiscordReactStep step={step} id={id} onUpdate={onUpdate} />;
+      case "discordGetMessage":
+        return <DiscordGetMessageStep step={step} id={id} onUpdate={onUpdate} />;
+      case "discordListMessages":
+        return <DiscordListMessagesStep step={step} id={id} onUpdate={onUpdate} />;
+      case "discordDeleteMessage":
+        return <DiscordDeleteMessageStep step={step} id={id} onUpdate={onUpdate} />;
       case "modifyVariable":
         return <ModifyVariableStep step={step} id={id} onUpdate={onUpdate} />;
       case "setVariable":

--- a/src/components/automationBuilder/nodeDetails/stepTypes/discord/DiscordCredentialField.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/discord/DiscordCredentialField.tsx
@@ -1,0 +1,81 @@
+import { Button } from "@components/ui/button";
+import { CredentialSelector } from "@components/ui/credential-selector";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { useState } from "react";
+
+interface DiscordCredentialFieldProps {
+  credentialId?: string;
+  botToken?: string;
+  onUpdate: (updates: { credentialId?: string; botToken?: string }) => void;
+}
+
+export function DiscordCredentialField({
+  credentialId,
+  botToken,
+  onUpdate,
+}: DiscordCredentialFieldProps) {
+  const [useManualCredentials, setUseManualCredentials] = useState(
+    !credentialId && !!botToken
+  );
+
+  const handleToggle = () => {
+    setUseManualCredentials(!useManualCredentials);
+    if (useManualCredentials) {
+      // Switching to saved credentials - clear manual fields
+      onUpdate({
+        credentialId: undefined,
+        botToken: undefined,
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <Label className="text-xs">Authentication</Label>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleToggle}
+          className="text-xs h-7"
+        >
+          {useManualCredentials ? "Use Saved Credential" : "Enter Manually"}
+        </Button>
+      </div>
+
+      {!useManualCredentials ? (
+        <CredentialSelector
+          type="discord"
+          value={credentialId}
+          onChange={(id) =>
+            onUpdate({
+              credentialId: id,
+              botToken: undefined,
+            })
+          }
+          label=""
+        />
+      ) : (
+        <>
+          <div className="space-y-2">
+            <Label className="text-xs">Bot Token</Label>
+            <Input
+              value={botToken || ""}
+              placeholder="Your Discord Bot Token"
+              onChange={(e) =>
+                onUpdate({
+                  botToken: e.target.value,
+                  credentialId: undefined,
+                })
+              }
+              className="text-xs"
+              type="password"
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/discord/DiscordDeleteMessageStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/discord/DiscordDeleteMessageStep.tsx
@@ -1,0 +1,38 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { DiscordCredentialField } from "./DiscordCredentialField";
+
+export function DiscordDeleteMessageStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "discordDeleteMessage") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Message ID</Label>
+        <Input
+          value={step.messageId || ""}
+          placeholder="Message ID"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, messageId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <DiscordCredentialField
+        credentialId={step.credentialId}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/discord/DiscordGetMessageStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/discord/DiscordGetMessageStep.tsx
@@ -1,0 +1,48 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { DiscordCredentialField } from "./DiscordCredentialField";
+
+export function DiscordGetMessageStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "discordGetMessage") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Message ID</Label>
+        <Input
+          value={step.messageId || ""}
+          placeholder="Message ID"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, messageId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <DiscordCredentialField
+        credentialId={step.credentialId}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/discord/DiscordListMessagesStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/discord/DiscordListMessagesStep.tsx
@@ -1,0 +1,52 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { DiscordCredentialField } from "./DiscordCredentialField";
+
+export function DiscordListMessagesStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "discordListMessages") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Limit</Label>
+        <Input
+          type="number"
+          value={step.limit?.toString() || "10"}
+          placeholder="1-100"
+          onChange={(e) =>
+            onUpdate(id, "update", { step: { ...step, limit: Number(e.target.value) } })
+          }
+          className="text-xs"
+        />
+        <p className="text-[11px] text-muted-foreground">Discord allows up to 100 per request.</p>
+      </div>
+
+      <DiscordCredentialField
+        credentialId={step.credentialId}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name (e.g., discordMessages)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/discord/DiscordReactStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/discord/DiscordReactStep.tsx
@@ -1,0 +1,49 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { DiscordCredentialField } from "./DiscordCredentialField";
+
+export function DiscordReactStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "discordReactMessage") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Message ID</Label>
+        <Input
+          value={step.messageId || ""}
+          placeholder="Message ID"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, messageId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Emoji</Label>
+        <Input
+          value={step.emoji || ""}
+          placeholder=":smile: or unicode codepoint"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, emoji: e.target.value } })}
+          className="text-xs"
+        />
+        <p className="text-[11px] text-muted-foreground">Use unicode or custom emoji name:id</p>
+      </div>
+
+      <DiscordCredentialField
+        credentialId={step.credentialId}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/discord/DiscordSendMessageStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/discord/DiscordSendMessageStep.tsx
@@ -1,0 +1,62 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { Switch } from "@components/ui/switch";
+import { Textarea } from "@components/ui/textarea";
+import { DiscordCredentialField } from "./DiscordCredentialField";
+
+export function DiscordSendMessageStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "discordSendMessage") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Message Content</Label>
+        <Textarea
+          value={step.content || ""}
+          placeholder="Message content (supports variables like {{name}})"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, content: e.target.value } })}
+          className="text-xs"
+          rows={4}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Switch
+          checked={!!step.tts}
+          onCheckedChange={(checked) => onUpdate(id, "update", { step: { ...step, tts: checked } })}
+          id={`${id}-tts`}
+        />
+        <Label htmlFor={`${id}-tts`} className="text-xs">
+          Text to Speech
+        </Label>
+      </div>
+
+      <DiscordCredentialField
+        credentialId={step.credentialId}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name (e.g., discordMessage)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/discord/DiscordSendWebhookStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/discord/DiscordSendWebhookStep.tsx
@@ -1,0 +1,93 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { Switch } from "@components/ui/switch";
+import { Textarea } from "@components/ui/textarea";
+
+export function DiscordSendWebhookStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "discordSendWebhook") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Webhook URL</Label>
+        <Input
+          value={step.webhookUrl || ""}
+          placeholder="https://discord.com/api/webhooks/..."
+          onChange={(e) =>
+            onUpdate(id, "update", { step: { ...step, webhookUrl: e.target.value } })
+          }
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Message Content</Label>
+        <Textarea
+          value={step.content || ""}
+          placeholder="Message content"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, content: e.target.value } })}
+          className="text-xs"
+          rows={4}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Username (optional)</Label>
+        <Input
+          value={step.username || ""}
+          placeholder="Display name override"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, username: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Avatar URL (optional)</Label>
+        <Input
+          value={step.avatarUrl || ""}
+          placeholder="Avatar image URL"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, avatarUrl: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Switch
+          checked={!!step.tts}
+          onCheckedChange={(checked) => onUpdate(id, "update", { step: { ...step, tts: checked } })}
+          id={`${id}-tts-webhook`}
+        />
+        <Label htmlFor={`${id}-tts-webhook`} className="text-xs">
+          Text to Speech
+        </Label>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Embeds JSON (optional)</Label>
+        <Textarea
+          value={step.embedsJson || ""}
+          placeholder='[{"title":"Hello","description":"World"}]'
+          onChange={(e) =>
+            onUpdate(id, "update", { step: { ...step, embedsJson: e.target.value } })
+          }
+          className="text-xs font-mono"
+          rows={3}
+        />
+        <p className="text-[11px] text-muted-foreground">
+          Provide an array of embed objects as JSON.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/index.ts
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/index.ts
@@ -6,6 +6,12 @@ import { ScrollStep } from "./browser/ScrollStep";
 import { SelectOptionStep } from "./browser/SelectOptionStep";
 import { TypeStep } from "./browser/TypeStep";
 import { WaitStep } from "./browser/WaitStep";
+import { DiscordDeleteMessageStep } from "./discord/DiscordDeleteMessageStep";
+import { DiscordGetMessageStep } from "./discord/DiscordGetMessageStep";
+import { DiscordListMessagesStep } from "./discord/DiscordListMessagesStep";
+import { DiscordReactStep } from "./discord/DiscordReactStep";
+import { DiscordSendMessageStep } from "./discord/DiscordSendMessageStep";
+import { DiscordSendWebhookStep } from "./discord/DiscordSendWebhookStep";
 import { ApiCallStep } from "./integration/ApiCallStep";
 import { TwitterCreateTweetStep } from "./twitter/TwitterCreateTweetStep";
 import { TwitterDeleteTweetStep } from "./twitter/TwitterDeleteTweetStep";
@@ -29,6 +35,12 @@ export {
   ScrollStep,
   ModifyVariableStep,
   SetVariableStep,
+  DiscordSendMessageStep,
+  DiscordSendWebhookStep,
+  DiscordReactStep,
+  DiscordGetMessageStep,
+  DiscordListMessagesStep,
+  DiscordDeleteMessageStep,
   TwitterCreateTweetStep,
   TwitterDeleteTweetStep,
   TwitterLikeTweetStep,

--- a/src/hooks/utils/nodeFactory.ts
+++ b/src/hooks/utils/nodeFactory.ts
@@ -112,6 +112,63 @@ export function createNode({
         body: "",
       };
       break;
+    case "discordSendMessage":
+      step = {
+        id: newId,
+        type: "discordSendMessage",
+        description: `${label} step`,
+        channelId: "",
+        content: "",
+        tts: false,
+      } as AutomationStep;
+      break;
+    case "discordSendWebhook":
+      step = {
+        id: newId,
+        type: "discordSendWebhook",
+        description: `${label} step`,
+        webhookUrl: "",
+        content: "",
+        tts: false,
+      } as AutomationStep;
+      break;
+    case "discordReactMessage":
+      step = {
+        id: newId,
+        type: "discordReactMessage",
+        description: `${label} step`,
+        channelId: "",
+        messageId: "",
+        emoji: "👍",
+      } as AutomationStep;
+      break;
+    case "discordGetMessage":
+      step = {
+        id: newId,
+        type: "discordGetMessage",
+        description: `${label} step`,
+        channelId: "",
+        messageId: "",
+      } as AutomationStep;
+      break;
+    case "discordListMessages":
+      step = {
+        id: newId,
+        type: "discordListMessages",
+        description: `${label} step`,
+        channelId: "",
+        limit: 10,
+      } as AutomationStep;
+      break;
+    case "discordDeleteMessage":
+      step = {
+        id: newId,
+        type: "discordDeleteMessage",
+        description: `${label} step`,
+        channelId: "",
+        messageId: "",
+      } as AutomationStep;
+      break;
     case "scroll":
       step = {
         id: newId,

--- a/src/main/credentialsStore.ts
+++ b/src/main/credentialsStore.ts
@@ -6,7 +6,7 @@ import path from "path";
 export interface Credential {
   id: string;
   name: string;
-  type: "twitter" | "oauth" | "apiKey" | "basic" | "custom";
+  type: "twitter" | "discord" | "oauth" | "apiKey" | "basic" | "custom";
   createdAt: string;
   updatedAt: string;
   data: Record<string, string>;

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -16,7 +16,7 @@ export interface WorkflowSchedule {
 export interface Credential {
   id: string;
   name: string;
-  type: "twitter" | "oauth" | "apiKey" | "basic" | "custom";
+  type: "twitter" | "discord" | "oauth" | "apiKey" | "basic" | "custom";
   createdAt: string;
   updatedAt: string;
   data: Record<string, string>;

--- a/src/types/steps.ts
+++ b/src/types/steps.ts
@@ -4,7 +4,11 @@ import {
   Code,
   GitBranch,
   Globe,
+  Hash,
+  MessageCircle,
   Mouse,
+  Send,
+  Smile,
   Twitter,
   Type as TypeIcon,
   Variable,
@@ -225,6 +229,65 @@ export interface StepTwitterSearchUser extends StepBase {
   storeKey?: string;
 }
 
+// Discord Integration Steps
+export interface StepDiscordSendMessage extends StepBase {
+  type: "discordSendMessage";
+  channelId: string;
+  content: string;
+  tts?: boolean;
+  credentialId?: string;
+  botToken?: string;
+  storeKey?: string;
+}
+
+export interface StepDiscordSendWebhook extends StepBase {
+  type: "discordSendWebhook";
+  webhookUrl?: string;
+  credentialId?: string;
+  botToken?: string;
+  content: string;
+  username?: string;
+  avatarUrl?: string;
+  tts?: boolean;
+  embedsJson?: string;
+  storeKey?: string;
+}
+
+export interface StepDiscordReactMessage extends StepBase {
+  type: "discordReactMessage";
+  channelId: string;
+  messageId: string;
+  emoji: string;
+  credentialId?: string;
+  botToken?: string;
+}
+
+export interface StepDiscordGetMessage extends StepBase {
+  type: "discordGetMessage";
+  channelId: string;
+  messageId: string;
+  credentialId?: string;
+  botToken?: string;
+  storeKey?: string;
+}
+
+export interface StepDiscordListMessages extends StepBase {
+  type: "discordListMessages";
+  channelId: string;
+  limit?: number;
+  credentialId?: string;
+  botToken?: string;
+  storeKey?: string;
+}
+
+export interface StepDiscordDeleteMessage extends StepBase {
+  type: "discordDeleteMessage";
+  channelId: string;
+  messageId: string;
+  credentialId?: string;
+  botToken?: string;
+}
+
 // Union of all supported steps used throughout the app
 export type AutomationStep =
   | StepNavigate
@@ -248,7 +311,13 @@ export type AutomationStep =
   | StepTwitterRetweet
   | StepTwitterSearchTweets
   | StepTwitterSendDM
-  | StepTwitterSearchUser;
+  | StepTwitterSearchUser
+  | StepDiscordSendMessage
+  | StepDiscordSendWebhook
+  | StepDiscordReactMessage
+  | StepDiscordGetMessage
+  | StepDiscordListMessages
+  | StepDiscordDeleteMessage;
 
 // UI meta for step type picker - organized by category
 export interface StepTypeOption {
@@ -341,6 +410,45 @@ export const integrationSteps: StepTypeOption[] = [
   },
 ];
 
+export const discordSteps: StepTypeOption[] = [
+  {
+    value: "discordSendMessage",
+    label: "Discord Send Message",
+    icon: MessageCircle,
+    description: "Send a message to a channel",
+  },
+  {
+    value: "discordSendWebhook",
+    label: "Discord Webhook",
+    icon: Send,
+    description: "Post a message via webhook",
+  },
+  {
+    value: "discordReactMessage",
+    label: "Discord React",
+    icon: Smile,
+    description: "Add a reaction to a message",
+  },
+  {
+    value: "discordGetMessage",
+    label: "Discord Get Message",
+    icon: Hash,
+    description: "Fetch a specific message",
+  },
+  {
+    value: "discordListMessages",
+    label: "Discord List Messages",
+    icon: Hash,
+    description: "List recent channel messages",
+  },
+  {
+    value: "discordDeleteMessage",
+    label: "Discord Delete Message",
+    icon: MessageCircle,
+    description: "Delete a message",
+  },
+];
+
 export const twitterSteps: StepTypeOption[] = [
   {
     value: "twitterCreateTweet",
@@ -408,6 +516,11 @@ export const stepCategories: StepCategory[] = [
     steps: integrationSteps,
   },
   {
+    category: "Discord",
+    icon: MessageCircle,
+    steps: discordSteps,
+  },
+  {
     category: "Twitter/X",
     icon: Twitter,
     steps: twitterSteps,
@@ -419,5 +532,6 @@ export const stepTypes = [
   ...dataSteps,
   ...logicSteps,
   ...integrationSteps,
+  ...discordSteps,
   ...twitterSteps,
 ] as const;


### PR DESCRIPTION
## Summary

Add full Discord node support (send message, webhook, react, get/list/delete) with manual vs saved credential toggle, Discord credential type/UI fields, and executor handling (bot token/webhook) plus optional response storage.


## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] My code follows the project's style