### PR TITLE
feature: integrated slack and related nodes

### DIFF
--- a/src/components/CredentialsManager.tsx
+++ b/src/components/CredentialsManager.tsx
@@ -110,6 +110,11 @@ export function CredentialsManager() {
           { key: "clientId", label: "Client ID (optional)", type: "text" },
           { key: "clientSecret", label: "Client Secret (optional)", type: "password" },
         ];
+      case "slack":
+        return [
+          { key: "apiToken", label: "API Token (Bot or User)", type: "password" },
+          { key: "botToken", label: "Bot Token (optional)", type: "password" },
+        ];
       case "openai":
         return [{ key: "apiKey", label: "OpenAI API Key", type: "password" }];
       case "anthropic":
@@ -169,6 +174,7 @@ export function CredentialsManager() {
               <SelectContent>
                 <SelectItem value="twitter">Twitter/X</SelectItem>
                 <SelectItem value="discord">Discord</SelectItem>
+                <SelectItem value="slack">Slack</SelectItem>
                 <SelectItem value="openai">OpenAI</SelectItem>
                 <SelectItem value="anthropic">Anthropic</SelectItem>
                 <SelectItem value="oauth">OAuth 2.0</SelectItem>

--- a/src/components/automationBuilder/AddStepPopup.tsx
+++ b/src/components/automationBuilder/AddStepPopup.tsx
@@ -2,6 +2,7 @@ import { AutomationStep, stepCategories } from "@app-types";
 import { Button } from "@components/ui/button";
 import { Card, CardContent, CardHeader } from "@components/ui/card";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@components/ui/collapsible";
+import { ScrollArea } from "@components/ui/scroll-area";
 import { GitBranch, Variable } from "lucide-react";
 import { useState } from "react";
 
@@ -27,70 +28,72 @@ const AddStepPopup: React.FC<AddStepPopupProps> = ({ onAdd }) => {
       <CardHeader className="p-3">
         <h3 className="text-sm font-medium">Add Step</h3>
       </CardHeader>
-      <CardContent className="p-3 space-y-2">
-        {stepCategories.map((categoryData) => (
-          <Collapsible
-            key={categoryData.category}
-            open={expandedCategories.has(categoryData.category)}
-            onOpenChange={() => toggleCategory(categoryData.category)}
-          >
-            <CollapsibleTrigger asChild>
-              <Button
-                variant="outline"
-                className="w-full text-left justify-between text-xs py-1 px-2 h-auto font-semibold"
-              >
-                <div className="flex items-center gap-2">
-                  {categoryData.icon && <categoryData.icon className="h-4 w-4" />}
-                  {categoryData.category}
-                </div>
-                <span className="text-xs">
-                  {expandedCategories.has(categoryData.category) ? "−" : "+"}
-                </span>
-              </Button>
-            </CollapsibleTrigger>
-            <CollapsibleContent className="space-y-1 pl-2 pt-1">
-              {categoryData.steps.map((stepType) => (
+      <ScrollArea className="h-[70vh] max-h-[600px]">
+        <CardContent className="p-3 space-y-2">
+          {stepCategories.map((categoryData) => (
+            <Collapsible
+              key={categoryData.category}
+              open={expandedCategories.has(categoryData.category)}
+              onOpenChange={() => toggleCategory(categoryData.category)}
+            >
+              <CollapsibleTrigger asChild>
                 <Button
-                  key={stepType.value}
-                  variant="ghost"
-                  className="w-full text-left justify-start text-xs py-1 px-2 hover:bg-gray-100"
-                  onClick={() => {
-                    onAdd(stepType.value as AutomationStep["type"]);
-                  }}
+                  variant="outline"
+                  className="w-full text-left justify-between text-xs py-1 px-2 h-auto font-semibold"
                 >
-                  <stepType.icon className="h-4 w-4 mr-2" />
-                  {stepType.label}
+                  <div className="flex items-center gap-2">
+                    {categoryData.icon && <categoryData.icon className="h-4 w-4" />}
+                    {categoryData.category}
+                  </div>
+                  <span className="text-xs">
+                    {expandedCategories.has(categoryData.category) ? "−" : "+"}
+                  </span>
                 </Button>
-              ))}
-            </CollapsibleContent>
-          </Collapsible>
-        ))}
+              </CollapsibleTrigger>
+              <CollapsibleContent className="space-y-1 pl-2 pt-1">
+                {categoryData.steps.map((stepType) => (
+                  <Button
+                    key={stepType.value}
+                    variant="ghost"
+                    className="w-full text-left justify-start text-xs py-1 px-2 hover:bg-gray-100"
+                    onClick={() => {
+                      onAdd(stepType.value as AutomationStep["type"]);
+                    }}
+                  >
+                    <stepType.icon className="h-4 w-4 mr-2" />
+                    {stepType.label}
+                  </Button>
+                ))}
+              </CollapsibleContent>
+            </Collapsible>
+          ))}
 
-        {/* Conditionals section */}
-        <div className="space-y-1">
-          <div className="text-xs font-semibold text-gray-500 px-2 py-1">Conditionals</div>
-          <Button
-            variant="outline"
-            className="w-full text-left justify-start text-xs py-1 px-2 h-auto"
-            onClick={() => {
-              onAdd("browserConditional");
-            }}
-          >
-            <GitBranch className="h-4 w-4 mr-2" />
-            Browser Conditional
-          </Button>
-          <Button
-            variant="outline"
-            className="w-full text-left justify-start text-xs py-1 px-2 h-auto"
-            onClick={() => {
-              onAdd("variableConditional");
-            }}
-          >
-            <Variable className="h-4 w-4 mr-2" />
-            Variable Conditional
-          </Button>
-        </div>
-      </CardContent>
+          {/* Conditionals section */}
+          <div className="space-y-1">
+            <div className="text-xs font-semibold text-gray-500 px-2 py-1">Conditionals</div>
+            <Button
+              variant="outline"
+              className="w-full text-left justify-start text-xs py-1 px-2 h-auto"
+              onClick={() => {
+                onAdd("browserConditional");
+              }}
+            >
+              <GitBranch className="h-4 w-4 mr-2" />
+              Browser Conditional
+            </Button>
+            <Button
+              variant="outline"
+              className="w-full text-left justify-start text-xs py-1 px-2 h-auto"
+              onClick={() => {
+                onAdd("variableConditional");
+              }}
+            >
+              <Variable className="h-4 w-4 mr-2" />
+              Variable Conditional
+            </Button>
+          </div>
+        </CardContent>
+      </ScrollArea>
     </Card>
   );
 };

--- a/src/components/automationBuilder/nodeDetails/StepEditor.tsx
+++ b/src/components/automationBuilder/nodeDetails/StepEditor.tsx
@@ -1,9 +1,3 @@
-/**
- * StepEditor - Dynamic editor for automation step configuration
- *
- * Routes to appropriate step-specific editor based on step type.
- * Each step type has its own component with custom fields and validation.
- */
 import type { ReactFlowNode } from "@app-types";
 import { Input } from "@components/ui/input";
 import { Label } from "@components/ui/label";
@@ -26,6 +20,22 @@ import {
   ScrollStep,
   SelectOptionStep,
   SetVariableStep,
+  SlackAddReactionStep,
+  SlackArchiveChannelStep,
+  SlackCreateChannelStep,
+  SlackDeleteMessageStep,
+  SlackGetChannelStep,
+  SlackGetHistoryStep,
+  SlackGetUserStep,
+  SlackInviteUsersStep,
+  SlackListChannelsStep,
+  SlackListMembersStep,
+  SlackListUsersStep,
+  SlackSendMessageStep,
+  SlackSetTopicStep,
+  SlackUnarchiveChannelStep,
+  SlackUpdateMessageStep,
+  SlackUploadFileStep,
   TwitterCreateTweetStep,
   TwitterDeleteTweetStep,
   TwitterLikeTweetStep,
@@ -132,6 +142,38 @@ export default function StepEditor({
         return <TwitterSendDMStep step={step} id={id} onUpdate={onUpdate} />;
       case "twitterSearchUser":
         return <TwitterSearchUserStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackSendMessage":
+        return <SlackSendMessageStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackUpdateMessage":
+        return <SlackUpdateMessageStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackDeleteMessage":
+        return <SlackDeleteMessageStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackCreateChannel":
+        return <SlackCreateChannelStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackGetChannel":
+        return <SlackGetChannelStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackListChannels":
+        return <SlackListChannelsStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackInviteUsers":
+        return <SlackInviteUsersStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackListMembers":
+        return <SlackListMembersStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackSetTopic":
+        return <SlackSetTopicStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackArchiveChannel":
+        return <SlackArchiveChannelStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackUnarchiveChannel":
+        return <SlackUnarchiveChannelStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackGetHistory":
+        return <SlackGetHistoryStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackGetUser":
+        return <SlackGetUserStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackListUsers":
+        return <SlackListUsersStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackAddReaction":
+        return <SlackAddReactionStep step={step} id={id} onUpdate={onUpdate} />;
+      case "slackUploadFile":
+        return <SlackUploadFileStep step={step} id={id} onUpdate={onUpdate} />;
       default:
         return null;
     }

--- a/src/components/automationBuilder/nodeDetails/stepTypes/index.ts
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/index.ts
@@ -16,6 +16,22 @@ import { AiAnthropicStep } from "./integration/AiAnthropicStep";
 import { AiOllamaStep } from "./integration/AiOllamaStep";
 import { AiOpenAIStep } from "./integration/AiOpenAIStep";
 import { ApiCallStep } from "./integration/ApiCallStep";
+import { SlackAddReactionStep } from "./slack/SlackAddReactionStep";
+import { SlackArchiveChannelStep } from "./slack/SlackArchiveChannelStep";
+import { SlackCreateChannelStep } from "./slack/SlackCreateChannelStep";
+import { SlackDeleteMessageStep } from "./slack/SlackDeleteMessageStep";
+import { SlackGetChannelStep } from "./slack/SlackGetChannelStep";
+import { SlackGetHistoryStep } from "./slack/SlackGetHistoryStep";
+import { SlackGetUserStep } from "./slack/SlackGetUserStep";
+import { SlackInviteUsersStep } from "./slack/SlackInviteUsersStep";
+import { SlackListChannelsStep } from "./slack/SlackListChannelsStep";
+import { SlackListMembersStep } from "./slack/SlackListMembersStep";
+import { SlackListUsersStep } from "./slack/SlackListUsersStep";
+import { SlackSendMessageStep } from "./slack/SlackSendMessageStep";
+import { SlackSetTopicStep } from "./slack/SlackSetTopicStep";
+import { SlackUnarchiveChannelStep } from "./slack/SlackUnarchiveChannelStep";
+import { SlackUpdateMessageStep } from "./slack/SlackUpdateMessageStep";
+import { SlackUploadFileStep } from "./slack/SlackUploadFileStep";
 import { TwitterCreateTweetStep } from "./twitter/TwitterCreateTweetStep";
 import { TwitterDeleteTweetStep } from "./twitter/TwitterDeleteTweetStep";
 import { TwitterLikeTweetStep } from "./twitter/TwitterLikeTweetStep";
@@ -54,4 +70,20 @@ export {
   TwitterSearchTweetsStep,
   TwitterSearchUserStep,
   TwitterSendDMStep,
+  SlackAddReactionStep,
+  SlackArchiveChannelStep,
+  SlackCreateChannelStep,
+  SlackDeleteMessageStep,
+  SlackGetChannelStep,
+  SlackGetHistoryStep,
+  SlackGetUserStep,
+  SlackInviteUsersStep,
+  SlackListChannelsStep,
+  SlackListMembersStep,
+  SlackListUsersStep,
+  SlackSendMessageStep,
+  SlackSetTopicStep,
+  SlackUnarchiveChannelStep,
+  SlackUpdateMessageStep,
+  SlackUploadFileStep,
 };

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackAddReactionStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackAddReactionStep.tsx
@@ -1,0 +1,61 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackAddReactionStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackAddReaction") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID (e.g., C123456)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Message Timestamp</Label>
+        <Input
+          value={step.timestamp || ""}
+          placeholder="Timestamp of message (e.g., 1503435956.000247)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, timestamp: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Emoji Name</Label>
+        <Input
+          value={step.reactionEmoji || ""}
+          placeholder="Emoji name without colons (e.g., thumbsup, heart)"
+          onChange={(e) =>
+            onUpdate(id, "update", { step: { ...step, reactionEmoji: e.target.value } })
+          }
+          className="text-xs"
+        />
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackArchiveChannelStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackArchiveChannelStep.tsx
@@ -1,0 +1,39 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackArchiveChannelStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackArchiveChannel") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID (e.g., C123456)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackCreateChannelStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackCreateChannelStep.tsx
@@ -1,0 +1,69 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { Switch } from "@components/ui/switch";
+import { Textarea } from "@components/ui/textarea";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackCreateChannelStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackCreateChannel") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel Name</Label>
+        <Input
+          value={step.channelName || ""}
+          placeholder="Channel name (e.g., general, my-project)"
+          onChange={(e) =>
+            onUpdate(id, "update", { step: { ...step, channelName: e.target.value } })
+          }
+          className="text-xs"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Switch
+          checked={!!step.isPrivate}
+          onCheckedChange={(checked) =>
+            onUpdate(id, "update", { step: { ...step, isPrivate: checked } })
+          }
+          id={`${id}-private`}
+        />
+        <Label htmlFor={`${id}-private`} className="text-xs">
+          Make Private Channel
+        </Label>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Channel Description (optional)</Label>
+        <Textarea
+          value={step.channelDescription || ""}
+          placeholder="Description for the channel"
+          onChange={(e) =>
+            onUpdate(id, "update", { step: { ...step, channelDescription: e.target.value } })
+          }
+          className="text-xs"
+          rows={3}
+        />
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name (e.g., newChannel)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackCredentialField.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackCredentialField.tsx
@@ -1,0 +1,99 @@
+import { Button } from "@components/ui/button";
+import { CredentialSelector } from "@components/ui/credential-selector";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { useState } from "react";
+
+interface SlackCredentialFieldProps {
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+  onUpdate: (creds: { credentialId?: string; apiToken?: string; botToken?: string }) => void;
+}
+
+export function SlackCredentialField({
+  credentialId,
+  apiToken,
+  botToken,
+  onUpdate,
+}: SlackCredentialFieldProps) {
+  const [useManualCredentials, setUseManualCredentials] = useState(!credentialId && !!apiToken);
+
+  const handleToggle = () => {
+    setUseManualCredentials(!useManualCredentials);
+    if (useManualCredentials) {
+      // Switching to saved credentials - clear manual fields
+      onUpdate({
+        credentialId: undefined,
+        apiToken: undefined,
+        botToken: undefined,
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <Label className="text-xs">Authentication</Label>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleToggle}
+          className="text-xs h-7"
+        >
+          {useManualCredentials ? "Use Saved Credential" : "Enter Manually"}
+        </Button>
+      </div>
+
+      {!useManualCredentials ? (
+        <CredentialSelector
+          type="slack"
+          value={credentialId}
+          onChange={(id) =>
+            onUpdate({
+              credentialId: id,
+              apiToken: undefined,
+              botToken: undefined,
+            })
+          }
+          label=""
+        />
+      ) : (
+        <>
+          <div className="space-y-2">
+            <Label className="text-xs">API Token</Label>
+            <Input
+              type="password"
+              value={apiToken || ""}
+              placeholder="xoxb-... (bot token) or xoxp-... (user token)"
+              onChange={(e) =>
+                onUpdate({
+                  apiToken: e.target.value,
+                  credentialId: undefined,
+                })
+              }
+              className="text-xs"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-xs">Bot Token (optional)</Label>
+            <Input
+              type="password"
+              value={botToken || ""}
+              placeholder="xoxb-... (alternative bot token)"
+              onChange={(e) =>
+                onUpdate({
+                  botToken: e.target.value,
+                  credentialId: undefined,
+                })
+              }
+              className="text-xs"
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackDeleteMessageStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackDeleteMessageStep.tsx
@@ -1,0 +1,49 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackDeleteMessageStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackDeleteMessage") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID (e.g., C123456)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Message Timestamp</Label>
+        <Input
+          value={step.timestamp || ""}
+          placeholder="Timestamp of message to delete (e.g., 1503435956.000247)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, timestamp: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackGetChannelStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackGetChannelStep.tsx
@@ -1,0 +1,53 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { Switch } from "@components/ui/switch";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackGetChannelStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackGetChannel") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID (e.g., C123456)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Switch
+          checked={!!step.includeNumMembers}
+          onCheckedChange={(checked) =>
+            onUpdate(id, "update", { step: { ...step, includeNumMembers: checked } })
+          }
+          id={`${id}-members`}
+        />
+        <Label htmlFor={`${id}-members`} className="text-xs">
+          Include Member Count
+        </Label>
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackGetHistoryStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackGetHistoryStep.tsx
@@ -1,0 +1,54 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackGetHistoryStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackGetHistory") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID (e.g., C123456)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Limit (optional)</Label>
+        <Input
+          type="number"
+          value={step.limit || ""}
+          placeholder="Maximum number of messages (default: 100)"
+          onChange={(e) =>
+            onUpdate(id, "update", {
+              step: { ...step, limit: e.target.value ? parseInt(e.target.value) : undefined },
+            })
+          }
+          className="text-xs"
+        />
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name (e.g., messages)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackGetUserStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackGetUserStep.tsx
@@ -1,0 +1,39 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackGetUserStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackGetUser") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">User ID</Label>
+        <Input
+          value={step.userId || ""}
+          placeholder="User ID (e.g., U123456)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, userId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name (e.g., user)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackInviteUsersStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackInviteUsersStep.tsx
@@ -1,0 +1,57 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { Textarea } from "@components/ui/textarea";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackInviteUsersStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackInviteUsers") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID (e.g., C123456)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">User IDs</Label>
+        <Textarea
+          value={Array.isArray(step.userIds) ? step.userIds.join("\n") : step.userIds || ""}
+          placeholder="User IDs (one per line) or comma-separated"
+          onChange={(e) => {
+            const userIds = e.target.value
+              .split("\n")
+              .map((s) => s.trim())
+              .filter((s) => s);
+            onUpdate(id, "update", { step: { ...step, userIds } });
+          }}
+          className="text-xs"
+          rows={4}
+        />
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackListChannelsStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackListChannelsStep.tsx
@@ -1,0 +1,58 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { Switch } from "@components/ui/switch";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackListChannelsStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackListChannels") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Limit (optional)</Label>
+        <Input
+          type="number"
+          value={step.limit || ""}
+          placeholder="Maximum number of channels to return (default: all)"
+          onChange={(e) =>
+            onUpdate(id, "update", {
+              step: { ...step, limit: e.target.value ? parseInt(e.target.value) : undefined },
+            })
+          }
+          className="text-xs"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Switch
+          checked={!!step.excludeArchived}
+          onCheckedChange={(checked) =>
+            onUpdate(id, "update", { step: { ...step, excludeArchived: checked } })
+          }
+          id={`${id}-exclude-archived`}
+        />
+        <Label htmlFor={`${id}-exclude-archived`} className="text-xs">
+          Exclude Archived Channels
+        </Label>
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name (e.g., channels)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackListMembersStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackListMembersStep.tsx
@@ -1,0 +1,39 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackListMembersStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackListMembers") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID (e.g., C123456)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name (e.g., members)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackListUsersStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackListUsersStep.tsx
@@ -1,0 +1,44 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackListUsersStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackListUsers") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Limit (optional)</Label>
+        <Input
+          type="number"
+          value={step.limit || ""}
+          placeholder="Maximum number of users (default: all)"
+          onChange={(e) =>
+            onUpdate(id, "update", {
+              step: { ...step, limit: e.target.value ? parseInt(e.target.value) : undefined },
+            })
+          }
+          className="text-xs"
+        />
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name (e.g., users)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackSendMessageStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackSendMessageStep.tsx
@@ -1,0 +1,101 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { Switch } from "@components/ui/switch";
+import { Textarea } from "@components/ui/textarea";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackSendMessageStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackSendMessage") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID or name (e.g., C123456 or #general)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Message Text</Label>
+        <Textarea
+          value={step.text || ""}
+          placeholder="Message content (supports variables like {{variableName}})"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, text: e.target.value } })}
+          className="text-xs"
+          rows={4}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Switch
+          checked={!!step.mrkdwn}
+          onCheckedChange={(checked) =>
+            onUpdate(id, "update", { step: { ...step, mrkdwn: checked } })
+          }
+          id={`${id}-mrkdwn`}
+        />
+        <Label htmlFor={`${id}-mrkdwn`} className="text-xs">
+          Enable Markdown
+        </Label>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Thread Timestamp (optional)</Label>
+        <Input
+          value={step.threadTs || ""}
+          placeholder="Leave empty for main channel, or use message timestamp for thread"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, threadTs: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Switch
+          checked={!!step.replyBroadcast}
+          onCheckedChange={(checked) =>
+            onUpdate(id, "update", { step: { ...step, replyBroadcast: checked } })
+          }
+          id={`${id}-broadcast`}
+        />
+        <Label htmlFor={`${id}-broadcast`} className="text-xs">
+          Reply Broadcast
+        </Label>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Blocks JSON (optional)</Label>
+        <Textarea
+          value={step.blocksJson || ""}
+          placeholder='{"type": "section", "text": {"type": "mrkdwn", "text": "..."}}'
+          onChange={(e) =>
+            onUpdate(id, "update", { step: { ...step, blocksJson: e.target.value } })
+          }
+          className="text-xs font-mono text-xs"
+          rows={3}
+        />
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name (e.g., slackMessage)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackSetTopicStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackSetTopicStep.tsx
@@ -1,0 +1,49 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackSetTopicStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackSetTopic") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID (e.g., C123456)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Topic</Label>
+        <Input
+          value={step.topic || ""}
+          placeholder="New channel topic"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, topic: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackUnarchiveChannelStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackUnarchiveChannelStep.tsx
@@ -1,0 +1,39 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackUnarchiveChannelStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackUnarchiveChannel") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID (e.g., C123456)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackUpdateMessageStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackUpdateMessageStep.tsx
@@ -1,0 +1,74 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { Textarea } from "@components/ui/textarea";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackUpdateMessageStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackUpdateMessage") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID (e.g., C123456)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Message Timestamp</Label>
+        <Input
+          value={step.timestamp || ""}
+          placeholder="Timestamp of message to update (e.g., 1503435956.000247)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, timestamp: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Updated Message Text</Label>
+        <Textarea
+          value={step.text || ""}
+          placeholder="New message content"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, text: e.target.value } })}
+          className="text-xs"
+          rows={4}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Blocks JSON (optional)</Label>
+        <Textarea
+          value={step.blocksJson || ""}
+          placeholder='{"type": "section", "text": {"type": "mrkdwn", "text": "..."}}'
+          onChange={(e) =>
+            onUpdate(id, "update", { step: { ...step, blocksJson: e.target.value } })
+          }
+          className="text-xs font-mono text-xs"
+          rows={3}
+        />
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackUploadFileStep.tsx
+++ b/src/components/automationBuilder/nodeDetails/stepTypes/slack/SlackUploadFileStep.tsx
@@ -1,0 +1,82 @@
+import { StepProps } from "@components/automationBuilder/nodeDetails/stepTypes/types";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { Textarea } from "@components/ui/textarea";
+import { SlackCredentialField } from "./SlackCredentialField";
+
+export function SlackUploadFileStep({ step, id, onUpdate }: StepProps) {
+  if (step.type !== "slackUploadFile") return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Channel ID</Label>
+        <Input
+          value={step.channelId || ""}
+          placeholder="Channel ID (e.g., C123456)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, channelId: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">File Path</Label>
+        <Input
+          value={step.filePath || ""}
+          placeholder="Path to file or URL to download from"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, filePath: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">File Name (optional)</Label>
+        <Input
+          value={step.fileName || ""}
+          placeholder="Filename (e.g., report.txt)"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, fileName: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Title (optional)</Label>
+        <Input
+          value={step.title || ""}
+          placeholder="Display title for the file"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, title: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Initial Comment (optional)</Label>
+        <Input
+          value={step.initialComment || ""}
+          placeholder="Comment to add with the file"
+          onChange={(e) =>
+            onUpdate(id, "update", { step: { ...step, initialComment: e.target.value } })
+          }
+          className="text-xs"
+        />
+      </div>
+
+      <SlackCredentialField
+        credentialId={step.credentialId}
+        apiToken={step.apiToken}
+        botToken={step.botToken}
+        onUpdate={(creds) => onUpdate(id, "update", { step: { ...step, ...creds } })}
+      />
+
+      <div className="space-y-2">
+        <Label className="text-xs">Store Response (optional)</Label>
+        <Input
+          value={step.storeKey || ""}
+          placeholder="Variable name"
+          onChange={(e) => onUpdate(id, "update", { step: { ...step, storeKey: e.target.value } })}
+          className="text-xs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/utils/nodeFactory.ts
+++ b/src/hooks/utils/nodeFactory.ts
@@ -336,6 +336,144 @@ export function createNode({
         accessSecret: "",
       };
       break;
+    case "slackSendMessage":
+      step = {
+        id: newId,
+        type: "slackSendMessage",
+        description: `${label} step`,
+        channelId: "",
+        text: "",
+        mrkdwn: false,
+      } as AutomationStep;
+      break;
+    case "slackUpdateMessage":
+      step = {
+        id: newId,
+        type: "slackUpdateMessage",
+        description: `${label} step`,
+        channelId: "",
+        timestamp: "",
+        text: "",
+      } as AutomationStep;
+      break;
+    case "slackDeleteMessage":
+      step = {
+        id: newId,
+        type: "slackDeleteMessage",
+        description: `${label} step`,
+        channelId: "",
+        timestamp: "",
+      } as AutomationStep;
+      break;
+    case "slackCreateChannel":
+      step = {
+        id: newId,
+        type: "slackCreateChannel",
+        description: `${label} step`,
+        channelName: "",
+        isPrivate: false,
+      } as AutomationStep;
+      break;
+    case "slackGetChannel":
+      step = {
+        id: newId,
+        type: "slackGetChannel",
+        description: `${label} step`,
+        channelId: "",
+      } as AutomationStep;
+      break;
+    case "slackListChannels":
+      step = {
+        id: newId,
+        type: "slackListChannels",
+        description: `${label} step`,
+        excludeArchived: true,
+      } as AutomationStep;
+      break;
+    case "slackInviteUsers":
+      step = {
+        id: newId,
+        type: "slackInviteUsers",
+        description: `${label} step`,
+        channelId: "",
+        userIds: [],
+      } as AutomationStep;
+      break;
+    case "slackListMembers":
+      step = {
+        id: newId,
+        type: "slackListMembers",
+        description: `${label} step`,
+        channelId: "",
+      } as AutomationStep;
+      break;
+    case "slackSetTopic":
+      step = {
+        id: newId,
+        type: "slackSetTopic",
+        description: `${label} step`,
+        channelId: "",
+        topic: "",
+      } as AutomationStep;
+      break;
+    case "slackArchiveChannel":
+      step = {
+        id: newId,
+        type: "slackArchiveChannel",
+        description: `${label} step`,
+        channelId: "",
+      } as AutomationStep;
+      break;
+    case "slackUnarchiveChannel":
+      step = {
+        id: newId,
+        type: "slackUnarchiveChannel",
+        description: `${label} step`,
+        channelId: "",
+      } as AutomationStep;
+      break;
+    case "slackGetHistory":
+      step = {
+        id: newId,
+        type: "slackGetHistory",
+        description: `${label} step`,
+        channelId: "",
+      } as AutomationStep;
+      break;
+    case "slackGetUser":
+      step = {
+        id: newId,
+        type: "slackGetUser",
+        description: `${label} step`,
+        userId: "",
+      } as AutomationStep;
+      break;
+    case "slackListUsers":
+      step = {
+        id: newId,
+        type: "slackListUsers",
+        description: `${label} step`,
+      } as AutomationStep;
+      break;
+    case "slackAddReaction":
+      step = {
+        id: newId,
+        type: "slackAddReaction",
+        description: `${label} step`,
+        channelId: "",
+        timestamp: "",
+        reactionEmoji: "",
+      } as AutomationStep;
+      break;
+    case "slackUploadFile":
+      step = {
+        id: newId,
+        type: "slackUploadFile",
+        description: `${label} step`,
+        channelId: "",
+        filePath: "",
+      } as AutomationStep;
+      break;
     default:
       step = { id: newId, type: "click", description: `${label} step`, selector: "body" };
   }

--- a/src/main/automationExecutor.ts
+++ b/src/main/automationExecutor.ts
@@ -6,6 +6,7 @@ import {
   BrowserStepHandler,
   ConditionalEvaluator,
   DiscordStepHandler,
+  SlackStepHandler,
   TwitterStepHandler,
   VariableManager,
   VariableOperationHandler,
@@ -24,6 +25,7 @@ export class AutomationExecutor {
   private aiHandler: AiStepHandler;
   private twitterHandler: TwitterStepHandler;
   private discordHandler: DiscordStepHandler;
+  private slackHandler: SlackStepHandler;
   private variableOperationHandler: VariableOperationHandler;
   private conditionalEvaluator: ConditionalEvaluator;
 
@@ -34,6 +36,7 @@ export class AutomationExecutor {
     this.aiHandler = new AiStepHandler();
     this.twitterHandler = new TwitterStepHandler();
     this.discordHandler = new DiscordStepHandler();
+    this.slackHandler = new SlackStepHandler();
     this.variableOperationHandler = new VariableOperationHandler();
     this.conditionalEvaluator = new ConditionalEvaluator();
   }
@@ -376,6 +379,151 @@ export class AutomationExecutor {
             step,
             this.substituteVariables.bind(this),
             this.resolveTwitterCredentials.bind(this),
+            variables
+          );
+          break;
+
+        // Slack steps
+        case "slackSendMessage":
+          result = await this.slackHandler.executeSendMessage(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+          break;
+
+        case "slackUpdateMessage":
+          result = await this.slackHandler.executeUpdateMessage(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+          break;
+
+        case "slackDeleteMessage":
+          result = await this.slackHandler.executeDeleteMessage(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+          break;
+
+        case "slackCreateChannel":
+          result = await this.slackHandler.executeCreateChannel(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+          break;
+
+        case "slackGetChannel":
+          result = await this.slackHandler.executeGetChannel(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+          break;
+
+        case "slackListChannels":
+          result = await this.slackHandler.executeListChannels(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+          break;
+
+        case "slackInviteUsers":
+          result = await this.slackHandler.executeInviteUsers(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+          break;
+
+        case "slackListMembers":
+          result = await this.slackHandler.executeListMembers(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+          break;
+
+        case "slackAddReaction":
+          result = await this.slackHandler.executeAddReaction(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+          break;
+
+        case "slackGetUser":
+          result = await this.slackHandler.executeGetUser(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+          break;
+
+        case "slackListUsers":
+          result = await this.slackHandler.executeListUsers(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+          break;
+
+        case "slackUploadFile":
+          result = await this.slackHandler.executeUploadFile(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+          break;
+
+        case "slackGetHistory":
+          result = await this.slackHandler.executeGetHistory(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+          break;
+
+        case "slackSetTopic":
+          result = await this.slackHandler.executeSetTopic(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+          break;
+
+        case "slackArchiveChannel":
+          result = await this.slackHandler.executeArchiveChannel(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+          break;
+
+        case "slackUnarchiveChannel":
+          result = await this.slackHandler.executeUnarchiveChannel(
+            step,
+            this.substituteVariables.bind(this),
+            SlackStepHandler.resolveSlackCredentials,
             variables
           );
           break;

--- a/src/main/credentialsStore.ts
+++ b/src/main/credentialsStore.ts
@@ -6,7 +6,16 @@ import path from "path";
 export interface Credential {
   id: string;
   name: string;
-  type: "twitter" | "discord" | "oauth" | "apiKey" | "basic" | "openai" | "anthropic" | "custom";
+  type:
+    | "twitter"
+    | "discord"
+    | "slack"
+    | "oauth"
+    | "apiKey"
+    | "basic"
+    | "openai"
+    | "anthropic"
+    | "custom";
   createdAt: string;
   updatedAt: string;
   data: Record<string, string>;

--- a/src/main/handlers/index.ts
+++ b/src/main/handlers/index.ts
@@ -5,6 +5,7 @@ export { ApiCallHandler } from "./apiCallHandler";
 export { BrowserStepHandler } from "./browserStepHandler";
 export { ConditionalEvaluator } from "./conditionalEvaluator";
 export { DiscordStepHandler } from "./discordStepHandler";
+export { SlackStepHandler } from "./slackStepHandler";
 export { TwitterStepHandler } from "./twitterStepHandler";
 export { VariableManager } from "./variableManager";
 export { VariableOperationHandler } from "./variableOperationHandler";

--- a/src/main/handlers/slackStepHandler.ts
+++ b/src/main/handlers/slackStepHandler.ts
@@ -1,0 +1,988 @@
+import type {
+  SlackAddReactionStep,
+  SlackArchiveChannelStep,
+  SlackCreateChannelStep,
+  SlackDeleteMessageStep,
+  SlackGetChannelStep,
+  SlackGetHistoryStep,
+  SlackGetUserStep,
+  SlackInviteUsersStep,
+  SlackListChannelsStep,
+  SlackListMembersStep,
+  SlackListUsersStep,
+  SlackSendMessageStep,
+  SlackSetTopicStep,
+  SlackUnarchiveChannelStep,
+  SlackUpdateMessageStep,
+  SlackUploadFileStep,
+} from "@app-types/slack";
+import { getCredential } from "@main/credentialsStore";
+import { debugLogger } from "@main/debugLogger";
+import axios from "axios";
+
+/**
+ * Handles all Slack-related automation steps
+ * Supports v1 and v2 API operations for channels, messages, users, files, and reactions
+ */
+export class SlackStepHandler {
+  /**
+   * Resolve Slack credentials from either credentialId or direct token
+   */
+  static async resolveSlackCredentials(step: {
+    credentialId?: string;
+    apiToken?: string;
+    botToken?: string;
+  }): Promise<{
+    token: string;
+  }> {
+    // If credentialId is provided, fetch from store
+    if (step.credentialId) {
+      const credential = await getCredential(step.credentialId);
+      if (!credential || credential.type !== "slack") {
+        throw new Error("Invalid or missing Slack credential");
+      }
+      const token = credential.data.token || credential.data.botToken || credential.data.apiToken;
+      if (!token) {
+        throw new Error("Slack credential missing token");
+      }
+      return { token };
+    }
+
+    // Otherwise use direct token
+    const token = step.apiToken || step.botToken;
+    if (!token) {
+      throw new Error("Slack token is required");
+    }
+    return { token };
+  }
+
+  /**
+   * Make a request to Slack API
+   */
+  private async slackRequest(
+    method: string,
+    endpoint: string,
+    token: string,
+    data?: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    try {
+      const config = {
+        method,
+        url: `https://slack.com/api${endpoint}`,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        data,
+      };
+
+      debugLogger.debug("Slack API Request", `${method} ${endpoint}`, config);
+
+      const response = await axios(config);
+
+      if (!response.data.ok) {
+        const error = response.data.error || "Unknown error";
+        throw new Error(`Slack API Error: ${error}`);
+      }
+
+      return response.data;
+    } catch (error: unknown) {
+      debugLogger.error(
+        "Slack API Error",
+        error instanceof Error ? error.message : String(error),
+        error
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Send a message to a channel (v1 & v2)
+   */
+  async executeSendMessage(
+    step: {
+      channelId: string;
+      text: string;
+      threadTs?: string;
+      replyBroadcast?: boolean;
+      mrkdwn?: boolean;
+      blocksJson?: string;
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const channelId = substituteVariables(step.channelId);
+    const text = substituteVariables(step.text);
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack Send Message", "Sending message", {
+      channelId,
+      text: text.substring(0, 100),
+    });
+
+    const payload: Record<string, unknown> = {
+      channel: channelId,
+      text,
+    };
+
+    if (step.threadTs) {
+      payload.thread_ts = substituteVariables(step.threadTs);
+    }
+
+    if (step.replyBroadcast !== undefined) {
+      payload.reply_broadcast = step.replyBroadcast;
+    }
+
+    if (step.mrkdwn !== undefined) {
+      payload.mrkdwn = step.mrkdwn;
+    }
+
+    if (step.blocksJson) {
+      try {
+        payload.blocks = JSON.parse(substituteVariables(step.blocksJson));
+      } catch (_) {
+        throw new Error("Invalid blocks JSON");
+      }
+    }
+
+    const response = await this.slackRequest("POST", "/chat.postMessage", token, payload);
+
+    if (step.storeKey) {
+      variables[step.storeKey] = response;
+    }
+
+    return response;
+  }
+
+  /**
+   * Update a message (v2)
+   */
+  async executeUpdateMessage(
+    step: {
+      channelId: string;
+      timestamp: string;
+      text: string;
+      blocksJson?: string;
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const channelId = substituteVariables(step.channelId);
+    const text = substituteVariables(step.text);
+    const timestamp = substituteVariables(step.timestamp);
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack Update Message", "Updating message", {
+      channelId,
+      timestamp,
+    });
+
+    const payload: Record<string, unknown> = {
+      channel: channelId,
+      ts: timestamp,
+      text,
+    };
+
+    if (step.blocksJson) {
+      try {
+        payload.blocks = JSON.parse(substituteVariables(step.blocksJson));
+      } catch (_) {
+        throw new Error("Invalid blocks JSON");
+      }
+    }
+
+    const response = await this.slackRequest("POST", "/chat.update", token, payload);
+
+    if (step.storeKey) {
+      variables[step.storeKey] = response;
+    }
+
+    return response;
+  }
+
+  /**
+   * Delete a message (v2)
+   */
+  async executeDeleteMessage(
+    step: {
+      channelId: string;
+      timestamp: string;
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const channelId = substituteVariables(step.channelId);
+    const timestamp = substituteVariables(step.timestamp);
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack Delete Message", "Deleting message", {
+      channelId,
+      timestamp,
+    });
+
+    const payload: Record<string, unknown> = {
+      channel: channelId,
+      ts: timestamp,
+    };
+
+    const response = await this.slackRequest("POST", "/chat.delete", token, payload);
+
+    if (step.storeKey) {
+      variables[step.storeKey] = response;
+    }
+
+    return response;
+  }
+
+  /**
+   * Create a channel (v1 & v2)
+   */
+  async executeCreateChannel(
+    step: {
+      channelName: string;
+      isPrivate?: boolean;
+      channelDescription?: string;
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const channelName = substituteVariables(step.channelName);
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack Create Channel", "Creating channel", {
+      channelName,
+      isPrivate: step.isPrivate,
+    });
+
+    const payload: Record<string, unknown> = {
+      name: channelName,
+    };
+
+    if (step.isPrivate !== undefined) {
+      payload.is_private = step.isPrivate;
+    }
+
+    if (step.channelDescription) {
+      payload.topic = {
+        value: substituteVariables(step.channelDescription),
+        canvas: false,
+      };
+    }
+
+    const response = await this.slackRequest("POST", "/conversations.create", token, payload);
+
+    if (step.storeKey) {
+      variables[step.storeKey] = response;
+    }
+
+    return response;
+  }
+
+  /**
+   * Get channel info (v2)
+   */
+  async executeGetChannel(
+    step: {
+      channelId: string;
+      includeNumMembers?: boolean;
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const channelId = substituteVariables(step.channelId);
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack Get Channel", "Getting channel info", { channelId });
+
+    const query = new URLSearchParams();
+    query.append("channel", channelId);
+    if (step.includeNumMembers) {
+      query.append("include_num_members", "true");
+    }
+
+    const response = await axios.get("https://slack.com/api/conversations.info", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      params: Object.fromEntries(query),
+    });
+
+    if (!response.data.ok) {
+      throw new Error(`Slack API Error: ${response.data.error}`);
+    }
+
+    if (step.storeKey) {
+      variables[step.storeKey] = response.data;
+    }
+
+    return response.data;
+  }
+
+  /**
+   * List channels (v1 & v2)
+   */
+  async executeListChannels(
+    step: {
+      limit?: number;
+      excludeArchived?: boolean;
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack List Channels", "Listing channels");
+
+    const query = new URLSearchParams();
+    if (step.limit) {
+      query.append("limit", step.limit.toString());
+    }
+    if (step.excludeArchived !== undefined) {
+      query.append("exclude_archived", step.excludeArchived ? "true" : "false");
+    }
+
+    const response = await axios.get("https://slack.com/api/conversations.list", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      params: Object.fromEntries(query),
+    });
+
+    if (!response.data.ok) {
+      throw new Error(`Slack API Error: ${response.data.error}`);
+    }
+
+    if (step.storeKey) {
+      variables[step.storeKey] = response.data;
+    }
+
+    return response.data;
+  }
+
+  /**
+   * Invite users to channel (v2)
+   */
+  async executeInviteUsers(
+    step: {
+      channelId: string;
+      userIds: string | string[];
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const channelId = substituteVariables(step.channelId);
+    let userIds = step.userIds;
+
+    if (typeof userIds === "string") {
+      userIds = substituteVariables(userIds)
+        .split(",")
+        .map((id) => id.trim());
+    } else if (Array.isArray(userIds)) {
+      userIds = userIds.map((id) => substituteVariables(id));
+    }
+
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack Invite Users", "Inviting users to channel", {
+      channelId,
+      userCount: (userIds as string[]).length,
+    });
+
+    const payload: Record<string, unknown> = {
+      channel: channelId,
+      users: (userIds as string[]).join(","),
+    };
+
+    const response = await this.slackRequest("POST", "/conversations.invite", token, payload);
+
+    if (step.storeKey) {
+      variables[step.storeKey] = response;
+    }
+
+    return response;
+  }
+
+  /**
+   * Get channel members (v2)
+   */
+  async executeListMembers(
+    step: {
+      channelId: string;
+      limit?: number;
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const channelId = substituteVariables(step.channelId);
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack List Members", "Getting channel members", {
+      channelId,
+    });
+
+    const query = new URLSearchParams();
+    query.append("channel", channelId);
+    if (step.limit) {
+      query.append("limit", step.limit.toString());
+    }
+
+    const response = await axios.get("https://slack.com/api/conversations.members", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      params: Object.fromEntries(query),
+    });
+
+    if (!response.data.ok) {
+      throw new Error(`Slack API Error: ${response.data.error}`);
+    }
+
+    if (step.storeKey) {
+      variables[step.storeKey] = response.data;
+    }
+
+    return response.data;
+  }
+
+  /**
+   * Add reaction to message (v2)
+   */
+  async executeAddReaction(
+    step: {
+      channelId: string;
+      timestamp: string;
+      reactionEmoji: string;
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const channelId = substituteVariables(step.channelId);
+    const timestamp = substituteVariables(step.timestamp);
+    let emoji = substituteVariables(step.reactionEmoji);
+
+    // Remove colons if present
+    emoji = emoji.replace(/:/g, "");
+
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack Add Reaction", "Adding reaction", {
+      channelId,
+      timestamp,
+      emoji,
+    });
+
+    const payload: Record<string, unknown> = {
+      channel: channelId,
+      timestamp,
+      name: emoji,
+    };
+
+    const response = await this.slackRequest("POST", "/reactions.add", token, payload);
+
+    if (step.storeKey) {
+      variables[step.storeKey] = response;
+    }
+
+    return response;
+  }
+
+  /**
+   * Get user info (v2)
+   */
+  async executeGetUser(
+    step: {
+      userId: string;
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const userId = substituteVariables(step.userId);
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack Get User", "Getting user info", { userId });
+
+    const query = new URLSearchParams();
+    query.append("user", userId);
+
+    const response = await axios.get("https://slack.com/api/users.info", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      params: Object.fromEntries(query),
+    });
+
+    if (!response.data.ok) {
+      throw new Error(`Slack API Error: ${response.data.error}`);
+    }
+
+    if (step.storeKey) {
+      variables[step.storeKey] = response.data;
+    }
+
+    return response.data;
+  }
+
+  /**
+   * List all users (v2)
+   */
+  async executeListUsers(
+    step: {
+      limit?: number;
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack List Users", "Listing users");
+
+    const query = new URLSearchParams();
+    if (step.limit) {
+      query.append("limit", step.limit.toString());
+    }
+
+    const response = await axios.get("https://slack.com/api/users.list", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      params: Object.fromEntries(query),
+    });
+
+    if (!response.data.ok) {
+      throw new Error(`Slack API Error: ${response.data.error}`);
+    }
+
+    if (step.storeKey) {
+      variables[step.storeKey] = response.data;
+    }
+
+    return response.data;
+  }
+
+  /**
+   * Upload a file to Slack (v2)
+   * Note: File upload via API is simplified - use direct upload for production
+   */
+  async executeUploadFile(
+    step: {
+      channelId: string;
+      filePath: string;
+      fileName?: string;
+      title?: string;
+      initialComment?: string;
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const channelId = substituteVariables(step.channelId);
+    const filePath = substituteVariables(step.filePath);
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack Upload File", "Uploading file", {
+      channelId,
+      filePath,
+    });
+
+    const payload: Record<string, unknown> = {
+      channels: channelId,
+    };
+
+    if (step.fileName) {
+      payload.filename = substituteVariables(step.fileName);
+    }
+
+    if (step.title) {
+      payload.title = substituteVariables(step.title);
+    }
+
+    if (step.initialComment) {
+      payload.initial_comment = substituteVariables(step.initialComment);
+    }
+
+    try {
+      const response = await this.slackRequest("POST", "/files.upload", token, payload);
+
+      if (step.storeKey) {
+        variables[step.storeKey] = response;
+      }
+
+      return response;
+    } catch (error: unknown) {
+      debugLogger.error("Slack Upload File", "File upload failed", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get message history from channel (v1 & v2)
+   */
+  async executeGetHistory(
+    step: {
+      channelId: string;
+      limit?: number;
+      oldestTimestamp?: string;
+      latestTimestamp?: string;
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const channelId = substituteVariables(step.channelId);
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack Get History", "Getting channel history", {
+      channelId,
+      limit: step.limit,
+    });
+
+    const query = new URLSearchParams();
+    query.append("channel", channelId);
+    if (step.limit) {
+      query.append("limit", step.limit.toString());
+    }
+    if (step.oldestTimestamp) {
+      query.append("oldest", substituteVariables(step.oldestTimestamp));
+    }
+    if (step.latestTimestamp) {
+      query.append("latest", substituteVariables(step.latestTimestamp));
+    }
+
+    const response = await axios.get("https://slack.com/api/conversations.history", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      params: Object.fromEntries(query),
+    });
+
+    if (!response.data.ok) {
+      throw new Error(`Slack API Error: ${response.data.error}`);
+    }
+
+    if (step.storeKey) {
+      variables[step.storeKey] = response.data;
+    }
+
+    return response.data;
+  }
+
+  /**
+   * Set channel topic (v2)
+   */
+  async executeSetTopic(
+    step: {
+      channelId: string;
+      topic: string;
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const channelId = substituteVariables(step.channelId);
+    const topic = substituteVariables(step.topic);
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack Set Topic", "Setting channel topic", {
+      channelId,
+      topic,
+    });
+
+    const payload: Record<string, unknown> = {
+      channel: channelId,
+      topic,
+    };
+
+    const response = await this.slackRequest("POST", "/conversations.setTopic", token, payload);
+
+    if (step.storeKey) {
+      variables[step.storeKey] = response;
+    }
+
+    return response;
+  }
+
+  /**
+   * Archive a channel (v2)
+   */
+  async executeArchiveChannel(
+    step: {
+      channelId: string;
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const channelId = substituteVariables(step.channelId);
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack Archive Channel", "Archiving channel", {
+      channelId,
+    });
+
+    const payload: Record<string, unknown> = {
+      channel: channelId,
+    };
+
+    const response = await this.slackRequest("POST", "/conversations.archive", token, payload);
+
+    if (step.storeKey) {
+      variables[step.storeKey] = response;
+    }
+
+    return response;
+  }
+
+  /**
+   * Unarchive a channel (v2)
+   */
+  async executeUnarchiveChannel(
+    step: {
+      channelId: string;
+      storeKey?: string;
+      credentialId?: string;
+      apiToken?: string;
+      botToken?: string;
+    },
+    substituteVariables: (input?: string) => string,
+    resolveSlackCredentials: (step: Record<string, unknown>) => Promise<{ token: string }>,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const channelId = substituteVariables(step.channelId);
+    const { token } = await resolveSlackCredentials(step);
+
+    debugLogger.debug("Slack Unarchive Channel", "Unarchiving channel", {
+      channelId,
+    });
+
+    const payload: Record<string, unknown> = {
+      channel: channelId,
+    };
+
+    const response = await this.slackRequest("POST", "/conversations.unarchive", token, payload);
+
+    if (step.storeKey) {
+      variables[step.storeKey] = response;
+    }
+
+    return response;
+  }
+
+  /**
+   * Main executor that routes to appropriate method
+   */
+  async execute(
+    step: Record<string, unknown>,
+    substituteVariables: (input?: string) => string,
+    variables: Record<string, unknown>
+  ): Promise<unknown> {
+    const operation = step.operation as string;
+    const resource = step.resource as string;
+
+    try {
+      switch (`${resource}.${operation}`) {
+        // Message operations
+        case "message.send":
+          return await this.executeSendMessage(
+            step as unknown as SlackSendMessageStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+        case "message.update":
+          return await this.executeUpdateMessage(
+            step as unknown as SlackUpdateMessageStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+        case "message.delete":
+          return await this.executeDeleteMessage(
+            step as unknown as SlackDeleteMessageStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+
+        // Channel operations
+        case "channel.create":
+          return await this.executeCreateChannel(
+            step as unknown as SlackCreateChannelStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+        case "channel.get":
+          return await this.executeGetChannel(
+            step as unknown as SlackGetChannelStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+        case "channel.getAll":
+        case "channel.list":
+          return await this.executeListChannels(
+            step as unknown as SlackListChannelsStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+        case "channel.invite":
+          return await this.executeInviteUsers(
+            step as unknown as SlackInviteUsersStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+        case "channel.member":
+        case "channel.members":
+          return await this.executeListMembers(
+            step as unknown as SlackListMembersStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+        case "channel.setTopic":
+        case "channel.setPurpose":
+          return await this.executeSetTopic(
+            step as unknown as SlackSetTopicStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+        case "channel.archive":
+          return await this.executeArchiveChannel(
+            step as unknown as SlackArchiveChannelStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+        case "channel.unarchive":
+          return await this.executeUnarchiveChannel(
+            step as unknown as SlackUnarchiveChannelStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+        case "channel.history":
+          return await this.executeGetHistory(
+            step as unknown as SlackGetHistoryStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+
+        // Reaction operations
+        case "reaction.add":
+          return await this.executeAddReaction(
+            step as unknown as SlackAddReactionStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+
+        // User operations
+        case "user.get":
+          return await this.executeGetUser(
+            step as unknown as SlackGetUserStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+        case "user.getAll":
+        case "user.list":
+          return await this.executeListUsers(
+            step as unknown as SlackListUsersStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+
+        // File operations
+        case "file.upload":
+          return await this.executeUploadFile(
+            step as unknown as SlackUploadFileStep,
+            substituteVariables,
+            SlackStepHandler.resolveSlackCredentials,
+            variables
+          );
+
+        default:
+          throw new Error(`Unknown Slack operation: ${resource}.${operation}`);
+      }
+    } catch (error: unknown) {
+      debugLogger.error("Slack Step Handler", `Error executing ${resource}.${operation}`, error);
+      throw error;
+    }
+  }
+}

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -16,7 +16,16 @@ export interface WorkflowSchedule {
 export interface Credential {
   id: string;
   name: string;
-  type: "twitter" | "discord" | "oauth" | "apiKey" | "basic" | "openai" | "anthropic" | "custom";
+  type:
+    | "twitter"
+    | "discord"
+    | "slack"
+    | "oauth"
+    | "apiKey"
+    | "basic"
+    | "openai"
+    | "anthropic"
+    | "custom";
   createdAt: string;
   updatedAt: string;
   data: Record<string, string>;

--- a/src/types/slack.ts
+++ b/src/types/slack.ts
@@ -1,0 +1,437 @@
+/**
+ * Slack automation step types and interfaces
+ * Supports both V1 and V2 API operations
+ */
+
+import type { StepBase } from "./steps";
+
+// ===== Message Operations =====
+export interface SlackSendMessageStep extends StepBase {
+  type: "slackSendMessage";
+  operation: "send";
+  resource: "message";
+  channelId: string;
+  text: string;
+  threadTs?: string;
+  replyBroadcast?: boolean;
+  mrkdwn?: boolean;
+  blocksJson?: string;
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+export interface SlackUpdateMessageStep extends StepBase {
+  type: "slackUpdateMessage";
+  operation: "update";
+  resource: "message";
+  channelId: string;
+  timestamp: string;
+  text: string;
+  blocksJson?: string;
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+export interface SlackDeleteMessageStep extends StepBase {
+  type: "slackDeleteMessage";
+  operation: "delete";
+  resource: "message";
+  channelId: string;
+  timestamp: string;
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+// ===== Channel Operations =====
+export interface SlackCreateChannelStep extends StepBase {
+  type: "slackCreateChannel";
+  operation: "create";
+  resource: "channel";
+  channelName: string;
+  isPrivate?: boolean;
+  channelDescription?: string;
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+export interface SlackGetChannelStep extends StepBase {
+  type: "slackGetChannel";
+  operation: "get";
+  resource: "channel";
+  channelId: string;
+  includeNumMembers?: boolean;
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+export interface SlackListChannelsStep extends StepBase {
+  type: "slackListChannels";
+  operation: "getAll" | "list";
+  resource: "channel";
+  limit?: number;
+  excludeArchived?: boolean;
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+export interface SlackInviteUsersStep extends StepBase {
+  type: "slackInviteUsers";
+  operation: "invite";
+  resource: "channel";
+  channelId: string;
+  userIds: string | string[];
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+export interface SlackListMembersStep extends StepBase {
+  type: "slackListMembers";
+  operation: "member" | "members";
+  resource: "channel";
+  channelId: string;
+  limit?: number;
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+export interface SlackSetTopicStep extends StepBase {
+  type: "slackSetTopic";
+  operation: "setTopic" | "setPurpose";
+  resource: "channel";
+  channelId: string;
+  topic: string;
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+export interface SlackArchiveChannelStep extends StepBase {
+  type: "slackArchiveChannel";
+  operation: "archive";
+  resource: "channel";
+  channelId: string;
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+export interface SlackUnarchiveChannelStep extends StepBase {
+  type: "slackUnarchiveChannel";
+  operation: "unarchive";
+  resource: "channel";
+  channelId: string;
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+export interface SlackGetHistoryStep extends StepBase {
+  type: "slackGetHistory";
+  operation: "history";
+  resource: "channel";
+  channelId: string;
+  limit?: number;
+  oldestTimestamp?: string;
+  latestTimestamp?: string;
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+// ===== User Operations =====
+export interface SlackGetUserStep extends StepBase {
+  type: "slackGetUser";
+  operation: "get";
+  resource: "user";
+  userId: string;
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+export interface SlackListUsersStep extends StepBase {
+  type: "slackListUsers";
+  operation: "getAll" | "list";
+  resource: "user";
+  limit?: number;
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+// ===== Reaction Operations =====
+export interface SlackAddReactionStep extends StepBase {
+  type: "slackAddReaction";
+  operation: "add";
+  resource: "reaction";
+  channelId: string;
+  timestamp: string;
+  reactionEmoji: string;
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+// ===== File Operations =====
+export interface SlackUploadFileStep extends StepBase {
+  type: "slackUploadFile";
+  operation: "upload";
+  resource: "file";
+  channelId: string;
+  filePath: string;
+  fileName?: string;
+  title?: string;
+  initialComment?: string;
+  storeKey?: string;
+  credentialId?: string;
+  apiToken?: string;
+  botToken?: string;
+}
+
+// ===== Union Type =====
+export type SlackAutomationStep =
+  | SlackSendMessageStep
+  | SlackUpdateMessageStep
+  | SlackDeleteMessageStep
+  | SlackCreateChannelStep
+  | SlackGetChannelStep
+  | SlackListChannelsStep
+  | SlackInviteUsersStep
+  | SlackListMembersStep
+  | SlackSetTopicStep
+  | SlackArchiveChannelStep
+  | SlackUnarchiveChannelStep
+  | SlackGetHistoryStep
+  | SlackGetUserStep
+  | SlackListUsersStep
+  | SlackAddReactionStep
+  | SlackUploadFileStep;
+
+// ===== API Response Types =====
+export interface SlackApiResponse {
+  ok: boolean;
+  error?: string;
+  response_metadata?: {
+    messages?: string[];
+    warnings?: string[];
+    next_cursor?: string;
+  };
+  [key: string]: unknown;
+}
+
+export interface SlackMessage {
+  type: string;
+  user: string;
+  text: string;
+  ts: string;
+  thread_ts?: string;
+  reply_count?: number;
+  reply_users_count?: number;
+  latest_reply?: string;
+  [key: string]: unknown;
+}
+
+export interface SlackChannel {
+  id: string;
+  name: string;
+  is_channel: boolean;
+  is_group: boolean;
+  is_im: boolean;
+  created: number;
+  creator: string;
+  is_archived: boolean;
+  is_general: boolean;
+  unlinked: number;
+  name_normalized: string;
+  is_shared: boolean;
+  is_ext_shared: boolean;
+  is_org_shared: boolean;
+  is_private: boolean;
+  is_mpim: boolean;
+  topic: {
+    value: string;
+    creator: string;
+    last_set: number;
+  };
+  purpose: {
+    value: string;
+    creator: string;
+    last_set: number;
+  };
+  num_members?: number;
+  members?: string[];
+  [key: string]: unknown;
+}
+
+export interface SlackUser {
+  id: string;
+  team_id: string;
+  name: string;
+  deleted: boolean;
+  color: string;
+  real_name: string;
+  tz: string;
+  tz_label: string;
+  tz_offset: number;
+  profile: {
+    title: string;
+    phone: string;
+    skype: string;
+    real_name: string;
+    real_name_normalized: string;
+    display_name: string;
+    display_name_normalized: string;
+    status_text: string;
+    status_emoji: string;
+    email: string;
+    image_24: string;
+    image_32: string;
+    image_48: string;
+    image_72: string;
+    image_192: string;
+    image_512: string;
+    [key: string]: unknown;
+  };
+  is_admin: boolean;
+  is_owner: boolean;
+  is_primary_owner: boolean;
+  is_restricted: boolean;
+  is_ultra_restricted: boolean;
+  is_bot: boolean;
+  updated: number;
+  is_app_user: boolean;
+  [key: string]: unknown;
+}
+
+export interface SlackFile {
+  id: string;
+  created: number;
+  timestamp: number;
+  name: string;
+  title: string;
+  mimetype: string;
+  filetype: string;
+  pretty_type: string;
+  user: string;
+  editable: boolean;
+  size: number;
+  mode: string;
+  is_external: boolean;
+  external_type: string;
+  is_public: boolean;
+  public_url_shared: boolean;
+  display_as_bot: boolean;
+  username: string;
+  url_private: string;
+  url_private_download: string;
+  thumb_64: string;
+  thumb_80: string;
+  thumb_160: string;
+  thumb_360: string;
+  thumb_360_w: number;
+  thumb_360_h: number;
+  thumb_480: string;
+  thumb_480_w: number;
+  thumb_480_h: number;
+  thumb_720: string;
+  thumb_720_w: number;
+  thumb_720_h: number;
+  thumb_960: string;
+  thumb_960_w: number;
+  thumb_960_h: number;
+  thumb_1024: string;
+  thumb_1024_w: number;
+  thumb_1024_h: number;
+  image_exif_rotation: number;
+  original_w: number;
+  original_h: number;
+  [key: string]: unknown;
+}
+
+export interface SlackReaction {
+  name: string;
+  users: string[];
+  count: number;
+}
+
+// ===== Credential Types =====
+export interface SlackCredential {
+  type: "slack" | "slackOAuth2";
+  data: {
+    token?: string;
+    botToken?: string;
+    apiToken?: string;
+    accessToken?: string;
+    slackTeamId?: string;
+    slackBotUserId?: string;
+    [key: string]: unknown;
+  };
+}
+
+// ===== V1 to V2 Migration =====
+export const V1_TO_V2_OPERATION_MAP: Record<string, string> = {
+  // Channel operations
+  "channel.getAll": "channel.list",
+  "channel.archive": "channel.archive",
+  "channel.unarchive": "channel.unarchive",
+  "channel.close": "channel.close",
+  "channel.create": "channel.create",
+  "channel.get": "channel.get",
+  "channel.history": "channel.history",
+  "channel.invite": "channel.invite",
+  "channel.join": "channel.join",
+  "channel.kick": "channel.kick",
+  "channel.leave": "channel.leave",
+  "channel.member": "channel.member",
+  "channel.open": "channel.open",
+  "channel.rename": "channel.rename",
+  "channel.replies": "channel.replies",
+  "channel.setPurpose": "channel.setTopic",
+  "channel.setTopic": "channel.setTopic",
+
+  // Message operations
+  "message.send": "message.send",
+
+  // File operations
+  "file.upload": "file.upload",
+  "file.delete": "file.delete",
+  "file.getAll": "file.list",
+  "file.get": "file.get",
+
+  // Reaction operations
+  "reaction.add": "reaction.add",
+  "reaction.remove": "reaction.remove",
+  "reaction.getAll": "reaction.list",
+  "reaction.get": "reaction.get",
+
+  // User operations
+  "user.get": "user.get",
+  "user.getAll": "user.list",
+
+  // User Group operations
+  "userGroup.getAll": "userGroup.list",
+  "userGroup.get": "userGroup.get",
+};

--- a/src/types/steps.ts
+++ b/src/types/steps.ts
@@ -15,6 +15,24 @@ import {
   Variable,
   Zap,
 } from "lucide-react";
+import type {
+  SlackAddReactionStep,
+  SlackArchiveChannelStep,
+  SlackCreateChannelStep,
+  SlackDeleteMessageStep,
+  SlackGetChannelStep,
+  SlackGetHistoryStep,
+  SlackGetUserStep,
+  SlackInviteUsersStep,
+  SlackListChannelsStep,
+  SlackListMembersStep,
+  SlackListUsersStep,
+  SlackSendMessageStep,
+  SlackSetTopicStep,
+  SlackUnarchiveChannelStep,
+  SlackUpdateMessageStep,
+  SlackUploadFileStep,
+} from "./slack";
 
 /**
  * Automation Step Type System
@@ -367,7 +385,23 @@ export type AutomationStep =
   | StepDiscordReactMessage
   | StepDiscordGetMessage
   | StepDiscordListMessages
-  | StepDiscordDeleteMessage;
+  | StepDiscordDeleteMessage
+  | SlackSendMessageStep
+  | SlackUpdateMessageStep
+  | SlackDeleteMessageStep
+  | SlackCreateChannelStep
+  | SlackGetChannelStep
+  | SlackListChannelsStep
+  | SlackInviteUsersStep
+  | SlackListMembersStep
+  | SlackSetTopicStep
+  | SlackArchiveChannelStep
+  | SlackUnarchiveChannelStep
+  | SlackGetHistoryStep
+  | SlackGetUserStep
+  | SlackListUsersStep
+  | SlackAddReactionStep
+  | SlackUploadFileStep;
 
 // UI meta for step type picker - organized by category
 export interface StepTypeOption {
@@ -565,6 +599,105 @@ export const twitterSteps: StepTypeOption[] = [
   },
 ];
 
+export const slackSteps: StepTypeOption[] = [
+  {
+    value: "slackSendMessage",
+    label: "Send Message",
+    icon: Send,
+    description: "Send a message to a Slack channel",
+  },
+  {
+    value: "slackUpdateMessage",
+    label: "Update Message",
+    icon: MessageCircle,
+    description: "Update an existing Slack message",
+  },
+  {
+    value: "slackDeleteMessage",
+    label: "Delete Message",
+    icon: MessageCircle,
+    description: "Delete a message from Slack",
+  },
+  {
+    value: "slackCreateChannel",
+    label: "Create Channel",
+    icon: Hash,
+    description: "Create a new Slack channel",
+  },
+  {
+    value: "slackGetChannel",
+    label: "Get Channel",
+    icon: Hash,
+    description: "Get information about a Slack channel",
+  },
+  {
+    value: "slackListChannels",
+    label: "List Channels",
+    icon: Hash,
+    description: "List all Slack channels",
+  },
+  {
+    value: "slackInviteUsers",
+    label: "Invite Users",
+    icon: Variable,
+    description: "Invite users to a Slack channel",
+  },
+  {
+    value: "slackListMembers",
+    label: "List Members",
+    icon: Variable,
+    description: "List members of a Slack channel",
+  },
+  {
+    value: "slackSetTopic",
+    label: "Set Topic",
+    icon: MessageCircle,
+    description: "Set the topic of a Slack channel",
+  },
+  {
+    value: "slackArchiveChannel",
+    label: "Archive Channel",
+    icon: Hash,
+    description: "Archive a Slack channel",
+  },
+  {
+    value: "slackUnarchiveChannel",
+    label: "Unarchive Channel",
+    icon: Hash,
+    description: "Unarchive a Slack channel",
+  },
+  {
+    value: "slackGetHistory",
+    label: "Get History",
+    icon: Clock,
+    description: "Get message history from a Slack channel",
+  },
+  {
+    value: "slackGetUser",
+    label: "Get User",
+    icon: Variable,
+    description: "Get information about a Slack user",
+  },
+  {
+    value: "slackListUsers",
+    label: "List Users",
+    icon: Variable,
+    description: "List all Slack workspace users",
+  },
+  {
+    value: "slackAddReaction",
+    label: "Add Reaction",
+    icon: Smile,
+    description: "Add an emoji reaction to a message",
+  },
+  {
+    value: "slackUploadFile",
+    label: "Upload File",
+    icon: Code,
+    description: "Upload a file to a Slack channel",
+  },
+];
+
 export const stepCategories: StepCategory[] = [
   {
     category: "Browser",
@@ -601,6 +734,11 @@ export const stepCategories: StepCategory[] = [
     icon: Twitter,
     steps: twitterSteps,
   },
+  {
+    category: "Slack",
+    icon: MessageCircle,
+    steps: slackSteps,
+  },
 ];
 
 export const stepTypes = [
@@ -611,4 +749,5 @@ export const stepTypes = [
   ...integrationSteps,
   ...discordSteps,
   ...twitterSteps,
+  ...slackSteps,
 ] as const;


### PR DESCRIPTION
## Summary

Add complete Slack integration to Loopi automation platform with support for 16 operations across messages, channels, users, reactions, and file uploads. Includes SlackStepHandler backend, UI components for all step types, credential management, and proper routing through AutomationExecutor.

### What's Included

**Backend**

- SlackStepHandler with 18 operations (message send/update/delete, channel create/list/archive, user info, reactions, file uploads)
- Full type safety with TypeScript interfaces
- Credential integration with encrypt/decrypt support
- Proper error handling

**U:**

- 16 step editor components with context-specific fields
- SlackCredentialField with toggle between saved credentials and manual input
- Scrollable Add Step Popup to handle expanded categories
- Consistent design matching Discord and Twitter integrations

**Integration**

- AutomationExecutor routing for all 16 operations
- Node factory support for step creation
- Credential type system integration
- Type definitions and UI metadata

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] My code follows the project's style
