### PR TITLE
security: no use of basic ftp patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,10 @@
     "tailwind-merge": "3.3.1",
     "tailwindcss": "^4.1.12",
     "vaul": "^1.1.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "basic-ftp": "npm:empty-npm-package@1.0.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  basic-ftp: npm:empty-npm-package@1.0.0
+
 importers:
 
   .:
@@ -2159,10 +2162,6 @@ packages:
     resolution: {integrity: sha512-616V5YX4bepJFzNyOfce5Fa8fDJMfoxzOIzDCZwaGL8MKVpFrXqfNUoIpRn9YMI5pXf/VKgzjB4htFMsFKKdiQ==}
     hasBin: true
 
-  basic-ftp@5.1.0:
-    resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
-    engines: {node: '>=10.0.0'}
-
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
 
@@ -2718,6 +2717,9 @@ packages:
   emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
+
+  empty-npm-package@1.0.0:
+    resolution: {integrity: sha512-q4Mq/+XO7UNDdMiPpR/LIBIW1Zl4V0Z6UT9aKGqIAnBCtCb3lvZJM1KbDbdzdC8fKflwflModfjR29Nt0EpcwA==}
 
   encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
@@ -7479,8 +7481,6 @@ snapshots:
 
   baseline-browser-mapping@2.8.23: {}
 
-  basic-ftp@5.1.0: {}
-
   batch@0.6.1: {}
 
   big.js@5.2.2: {}
@@ -8092,6 +8092,8 @@ snapshots:
 
   emojis-list@3.0.0: {}
 
+  empty-npm-package@1.0.0: {}
+
   encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
@@ -8517,7 +8519,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.1.0
+      basic-ftp: empty-npm-package@1.0.0
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- Security: Remove basic-ftp — Replaced basic-ftp (transitive dep via proxy-agent → get-uri) with an empty stub via pnpm override to mitigate CVE
  path traversal vulnerability in downloadToDir(). The app never uses FTP protocol.
