### PR TITLE
feat(ui): premium editorial redesign — warm parchment + terracotta palette (v1.10.0)

### DIFF
--- a/docs/examples/desktop_keyboard_typing.json
+++ b/docs/examples/desktop_keyboard_typing.json
@@ -97,7 +97,7 @@
           "type": "setVariable",
           "description": "Set a dynamic message",
           "variableName": "timestamp",
-          "value": "Typed at runtime via Loopi v1.9.1"
+          "value": "Typed at runtime via Loopi v1.10.0"
         }
       },
       "position": { "x": 300, "y": 830 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopi",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "Loopi — Visual Browser & Desktop Automation for humans and teams",
   "author": "Dyan-Dev",
   "main": ".webpack/main",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -114,14 +114,19 @@ export default function App() {
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
-      <header className="border-b border-border bg-card">
+      <header className="sticky top-0 z-40 border-b border-border/70 bg-background/80 backdrop-blur-xl supports-[backdrop-filter]:bg-background/60">
         <div className="flex h-16 items-center justify-between px-6">
-          <div className="flex items-center space-x-2">
-            <img src={loopLogo} alt="Loopi" className="h-8 w-8" />
-            <h1 className="text-xl font-semibold">Loopi</h1>
+          <div className="flex items-center gap-2.5">
+            <div className="relative">
+              <div className="absolute inset-0 rounded-lg bg-primary/20 blur-md -z-10" aria-hidden />
+              <img src={loopLogo} alt="Loopi" className="h-8 w-8 relative" />
+            </div>
+            <h1 className="font-serif text-xl tracking-tight">
+              <span className="ink-gradient">Loopi</span>
+            </h1>
           </div>
 
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center gap-3">
             <Tabs
               value={currentView}
               onValueChange={(value: string) => {
@@ -139,25 +144,40 @@ export default function App() {
                 }
               }}
             >
-              <TabsList>
-                <TabsTrigger value="chat">
-                  <MessageSquare className="h-4 w-4 mr-1" />
+              <TabsList className="h-10 p-1 rounded-xl bg-muted/60 backdrop-blur">
+                <TabsTrigger
+                  value="chat"
+                  className="rounded-lg px-3 data-[state=active]:bg-card data-[state=active]:shadow-[0_1px_0_rgba(255,255,255,0.7)_inset,0_2px_6px_-2px_rgba(42,19,11,0.1)] data-[state=active]:text-primary"
+                >
+                  <MessageSquare className="h-4 w-4 mr-1.5" />
                   Chat
                 </TabsTrigger>
-                <TabsTrigger value="agents">
-                  <Users className="h-4 w-4 mr-1" />
+                <TabsTrigger
+                  value="agents"
+                  className="rounded-lg px-3 data-[state=active]:bg-card data-[state=active]:shadow-[0_1px_0_rgba(255,255,255,0.7)_inset,0_2px_6px_-2px_rgba(42,19,11,0.1)] data-[state=active]:text-primary"
+                >
+                  <Users className="h-4 w-4 mr-1.5" />
                   Agents
                 </TabsTrigger>
-                <TabsTrigger value="dashboard">
-                  <Grid className="h-4 w-4 mr-1" />
+                <TabsTrigger
+                  value="dashboard"
+                  className="rounded-lg px-3 data-[state=active]:bg-card data-[state=active]:shadow-[0_1px_0_rgba(255,255,255,0.7)_inset,0_2px_6px_-2px_rgba(42,19,11,0.1)] data-[state=active]:text-primary"
+                >
+                  <Grid className="h-4 w-4 mr-1.5" />
                   Dashboard
                 </TabsTrigger>
-                <TabsTrigger value="builder">
-                  <Bot className="h-4 w-4 mr-1" />
+                <TabsTrigger
+                  value="builder"
+                  className="rounded-lg px-3 data-[state=active]:bg-card data-[state=active]:shadow-[0_1px_0_rgba(255,255,255,0.7)_inset,0_2px_6px_-2px_rgba(42,19,11,0.1)] data-[state=active]:text-primary"
+                >
+                  <Bot className="h-4 w-4 mr-1.5" />
                   Builder
                 </TabsTrigger>
-                <TabsTrigger value="scheduler">
-                  <SettingsIcon className="h-4 w-4 mr-1" />
+                <TabsTrigger
+                  value="scheduler"
+                  className="rounded-lg px-3 data-[state=active]:bg-card data-[state=active]:shadow-[0_1px_0_rgba(255,255,255,0.7)_inset,0_2px_6px_-2px_rgba(42,19,11,0.1)] data-[state=active]:text-primary"
+                >
+                  <SettingsIcon className="h-4 w-4 mr-1.5" />
                   Scheduler
                 </TabsTrigger>
               </TabsList>
@@ -167,7 +187,11 @@ export default function App() {
               variant="ghost"
               size="icon"
               onClick={() => setCurrentView("settings")}
-              className={currentView === "settings" ? "bg-accent" : ""}
+              className={
+                currentView === "settings"
+                  ? "bg-accent text-primary rounded-xl"
+                  : "rounded-xl hover:text-primary"
+              }
               title="Settings"
             >
               <SettingsIcon className="h-5 w-5" />

--- a/src/components/AgentsPanel.tsx
+++ b/src/components/AgentsPanel.tsx
@@ -90,22 +90,36 @@ export function AgentsPanel({ onOpenWorkflow }: AgentsPanelProps) {
   return (
     <div className="container mx-auto p-6 max-w-6xl">
       {/* Header */}
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h2 className="text-2xl font-bold">Agents</h2>
-          <p className="text-sm text-muted-foreground">
-            AI agents that execute tasks using workflows, APIs, and desktop controls
-          </p>
-        </div>
-        <div className="flex gap-2">
-          <Button variant="outline" size="sm" onClick={loadAgents}>
-            <RefreshCw className="h-4 w-4 mr-1" />
-            Refresh
-          </Button>
-          <Button size="sm" onClick={() => setCreateOpen(true)}>
-            <Plus className="h-4 w-4 mr-1" />
-            Create Agent
-          </Button>
+      <div className="relative overflow-hidden rounded-2xl border border-border/70 bg-card p-6 sm:p-7 mb-6 grain">
+        <div className="absolute inset-0 mesh-warm opacity-35 pointer-events-none" aria-hidden />
+        <div className="relative flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+          <div className="max-w-xl">
+            <span className="inline-flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.18em] text-primary mb-3">
+              <span className="w-5 h-px bg-primary/60" />
+              Agents
+            </span>
+            <h2 className="font-serif text-3xl leading-[1.05] tracking-tight mb-2">
+              Goal‑driven workers that{" "}
+              <em className="not-italic ink-gradient">patch themselves</em>.
+            </h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              AI agents that execute tasks using workflows, APIs, and desktop controls. Reflection rewrites failing workflows in place.
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={loadAgents} className="backdrop-blur bg-card/80">
+              <RefreshCw className="h-4 w-4 mr-1" />
+              Refresh
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => setCreateOpen(true)}
+              className="shadow-premium hover:shadow-premium-hover hover:-translate-y-0.5 active:translate-y-0 transition-all"
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              Create Agent
+            </Button>
+          </div>
         </div>
       </div>
 
@@ -115,18 +129,29 @@ export function AgentsPanel({ onOpenWorkflow }: AgentsPanelProps) {
           Loading agents...
         </div>
       ) : agents.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-20 text-center">
-          <Bot className="h-16 w-16 text-muted-foreground/30 mb-4" />
-          <h3 className="text-lg font-medium mb-2">No agents yet</h3>
-          <p className="text-sm text-muted-foreground mb-4 max-w-md">
-            Create agents to automate complex tasks. Agents can run workflows, make API calls,
-            control your desktop, and more. You can also ask Loopi in the Chat tab to create agents
-            for you.
-          </p>
-          <Button onClick={() => setCreateOpen(true)}>
-            <Plus className="h-4 w-4 mr-1" />
-            Create Your First Agent
-          </Button>
+        <div className="relative overflow-hidden rounded-2xl border border-dashed border-border/70 py-20 text-center grain">
+          <div className="absolute inset-0 surface-dotted opacity-25 pointer-events-none" aria-hidden />
+          <div className="relative flex flex-col items-center">
+            <div className="relative mb-5">
+              <div className="absolute inset-0 bg-primary/30 blur-2xl rounded-full" aria-hidden />
+              <div className="relative w-16 h-16 rounded-2xl bg-gradient-to-br from-primary to-primary/80 flex items-center justify-center shadow-[0_1px_0_rgba(255,255,255,0.25)_inset,0_8px_24px_-8px_rgba(193,95,54,0.5)]">
+                <Bot className="h-8 w-8 text-primary-foreground" />
+              </div>
+            </div>
+            <h3 className="font-serif text-xl mb-2">No agents yet</h3>
+            <p className="text-sm text-muted-foreground mb-6 max-w-md leading-relaxed">
+              Create agents to automate complex tasks. Agents can run workflows, make API calls,
+              control your desktop, and more. You can also ask Loopi in the Chat tab to create agents
+              for you.
+            </p>
+            <Button
+              onClick={() => setCreateOpen(true)}
+              className="shadow-premium hover:shadow-premium-hover hover:-translate-y-0.5 active:translate-y-0 transition-all"
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              Create Your First Agent
+            </Button>
+          </div>
         </div>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1423,14 +1423,24 @@ export function Chat() {
       {/* Messages area */}
       <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
         {messages.length === 0 && (
-          <div className="flex items-center justify-center h-full">
-            <div className="text-center space-y-3 max-w-md">
-              <MessageSquare className="h-12 w-12 text-muted-foreground/30 mx-auto" />
-              <h3 className="text-lg font-medium text-muted-foreground">Start a conversation</h3>
-              <p className="text-sm text-muted-foreground/70">
-                Ask Loopi anything about automations, get help debugging workflows, or request
-                assistance with building new ones.
-              </p>
+          <div className="relative flex items-center justify-center h-full grain overflow-hidden">
+            <div className="absolute inset-0 mesh-warm opacity-30 pointer-events-none" aria-hidden />
+            <div className="relative text-center space-y-4 max-w-md px-6">
+              <div className="relative mx-auto w-16 h-16">
+                <div className="absolute inset-0 bg-primary/25 blur-2xl rounded-full" aria-hidden />
+                <div className="relative w-16 h-16 rounded-2xl bg-gradient-to-br from-primary to-primary/80 flex items-center justify-center shadow-[0_1px_0_rgba(255,255,255,0.25)_inset,0_8px_24px_-8px_rgba(193,95,54,0.5)]">
+                  <MessageSquare className="h-7 w-7 text-primary-foreground" />
+                </div>
+              </div>
+              <div>
+                <h3 className="font-serif text-2xl tracking-tight mb-2">
+                  Ask Loopi <em className="not-italic ink-gradient">anything</em>.
+                </h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  Ask about automations, get help debugging workflows, request a new one, or tell
+                  Loopi to spin up an agent for you.
+                </p>
+              </div>
             </div>
           </div>
         )}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -106,21 +106,46 @@ export function Dashboard({
   const totalAutomations = automations.length;
 
   return (
-    <div className="p-6 space-y-6">
-      {/* Main Action Buttons */}
-      <div className="flex gap-4">
-        <Button onClick={onCreateAutomation} size="lg">
-          <Plus className="h-5 w-5 mr-2" />
-          Add Automation
-        </Button>
-        <Button onClick={handleImportAutomation} variant="outline" size="lg">
-          <Upload className="h-5 w-5 mr-2" />
-          Import
-        </Button>
-        <Button onClick={() => setAiDialogOpen(true)} variant="outline" size="lg">
-          <Sparkles className="h-5 w-5 mr-2" />
-          AI Generate
-        </Button>
+    <div className="relative p-6 space-y-6">
+      {/* Editorial header band */}
+      <div className="relative overflow-hidden rounded-2xl border border-border/70 bg-card p-6 sm:p-8 grain">
+        <div className="absolute inset-0 mesh-warm opacity-40 pointer-events-none" aria-hidden />
+        <div className="absolute inset-0 surface-dotted opacity-20 pointer-events-none" aria-hidden />
+        <div className="relative flex flex-col sm:flex-row sm:items-end sm:justify-between gap-5">
+          <div className="max-w-xl">
+            <span className="inline-flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.18em] text-primary mb-3">
+              <span className="w-5 h-px bg-primary/60" />
+              Workspace
+            </span>
+            <h2 className="font-serif text-3xl sm:text-4xl leading-[1.05] tracking-tight mb-2">
+              Build what you want.{" "}
+              <em className="not-italic ink-gradient">Loopi runs it.</em>
+            </h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {totalAutomations === 0
+                ? "No automations yet. Start from scratch, import a file, or ask the AI copilot to draft one for you."
+                : `${totalAutomations} automation${totalAutomations === 1 ? "" : "s"} ready to run. Drop into the builder or schedule them up.`}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2.5">
+            <Button
+              onClick={onCreateAutomation}
+              size="lg"
+              className="shadow-premium hover:shadow-premium-hover hover:-translate-y-0.5 active:translate-y-0 transition-all"
+            >
+              <Plus className="h-5 w-5 mr-2" />
+              Add Automation
+            </Button>
+            <Button onClick={handleImportAutomation} variant="outline" size="lg" className="backdrop-blur bg-card/80">
+              <Upload className="h-5 w-5 mr-2" />
+              Import
+            </Button>
+            <Button onClick={() => setAiDialogOpen(true)} variant="outline" size="lg" className="backdrop-blur bg-card/80 group">
+              <Sparkles className="h-5 w-5 mr-2 text-primary group-hover:rotate-12 transition-transform" />
+              AI Generate
+            </Button>
+          </div>
+        </div>
       </div>
 
       {/* Tabs Section */}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -206,7 +206,7 @@ export function Settings() {
                   <span className="font-semibold">App Name:</span> Loopi
                 </p>
                 <p className="text-sm">
-                  <span className="font-semibold">Version:</span> 1.9.1
+                  <span className="font-semibold">Version:</span> 1.10.0
                 </p>
                 <p className="text-sm">
                   <span className="font-semibold">Platform:</span> Workflow Automation

--- a/src/components/agents/AgentCard.tsx
+++ b/src/components/agents/AgentCard.tsx
@@ -13,10 +13,14 @@ interface AgentCardProps {
 }
 
 const STATUS_COLORS: Record<string, string> = {
-  active: "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
-  running: "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
-  stopped: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
-  failed: "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+  active:
+    "bg-emerald-100 text-emerald-700 border-emerald-200/80 dark:bg-emerald-950/50 dark:text-emerald-300 dark:border-emerald-900/60",
+  running:
+    "bg-emerald-100 text-emerald-700 border-emerald-200/80 dark:bg-emerald-950/50 dark:text-emerald-300 dark:border-emerald-900/60",
+  stopped:
+    "bg-muted text-muted-foreground border-border",
+  failed:
+    "bg-red-100 text-red-700 border-red-200/80 dark:bg-red-950/50 dark:text-red-300 dark:border-red-900/60",
 };
 
 function displayStatus(agent: Agent): string {
@@ -44,15 +48,28 @@ export function AgentCard({ agent, onStart, onStop, onDelete, onClick }: AgentCa
 
   return (
     <Card
-      className="p-4 cursor-pointer hover:border-primary/50 transition-colors"
+      className="card-premium relative p-5 cursor-pointer overflow-hidden"
       onClick={() => onClick(agent)}
     >
-      <div className="flex items-start justify-between mb-3">
-        <div className="min-w-0 flex-1">
-          <h3 className="font-semibold text-sm truncate">{agent.name}</h3>
-          <p className="text-xs text-muted-foreground truncate">{agent.role}</p>
+      {status === "running" && (
+        <div className="absolute top-0 inset-x-0 h-px bg-gradient-to-r from-transparent via-emerald-500 to-transparent" aria-hidden />
+      )}
+      <div className="flex items-start justify-between mb-3 gap-2">
+        <div className="flex items-start gap-3 min-w-0 flex-1">
+          <div className="shrink-0 w-9 h-9 rounded-lg bg-gradient-to-br from-primary to-primary/80 text-primary-foreground flex items-center justify-center font-serif text-sm shadow-[0_1px_0_rgba(255,255,255,0.2)_inset,0_4px_12px_-4px_rgba(193,95,54,0.45)]">
+            {agent.name.charAt(0).toUpperCase()}
+          </div>
+          <div className="min-w-0 flex-1">
+            <h3 className="font-semibold text-sm truncate leading-tight">{agent.name}</h3>
+            <p className="text-xs text-muted-foreground truncate mt-0.5">{agent.role}</p>
+          </div>
         </div>
-        <Badge className={`ml-2 text-xs ${STATUS_COLORS[status] || ""}`}>{status}</Badge>
+        <Badge variant="outline" className={`text-[10px] font-medium uppercase tracking-wider border ${STATUS_COLORS[status] || ""}`}>
+          {status === "running" && (
+            <span className="mr-1 inline-block w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
+          )}
+          {status}
+        </Badge>
       </div>
 
       {agent.goal && (

--- a/src/index.css
+++ b/src/index.css
@@ -3,81 +3,129 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --font-size: 16px;
-  --background: #ffffff;
-  --foreground: oklch(0.145 0 0);
+  --font-size: 14.5px;
+
+  /* Warm editorial palette — matches loopi.site */
+  --background: #faf8f3;           /* parchment */
+  --foreground: #1a1510;           /* warm ink */
   --card: #ffffff;
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: #030213;
-  --primary-foreground: oklch(1 0 0);
-  --secondary: oklch(0.95 0.0058 264.53);
-  --secondary-foreground: #030213;
-  --muted: #ececf0;
-  --muted-foreground: #717182;
-  --accent: #e9ebef;
-  --accent-foreground: #030213;
-  --destructive: #d4183d;
+  --card-foreground: #1a1510;
+  --popover: #ffffff;
+  --popover-foreground: #1a1510;
+
+  /* Primary — terracotta (#c15f36) */
+  --primary: #c15f36;
+  --primary-foreground: #ffffff;
+
+  /* Secondary — warm copper mid-tone */
+  --secondary: #f3efe6;
+  --secondary-foreground: #1a1510;
+
+  --muted: #f3efe6;
+  --muted-foreground: #75694f;
+  --accent: #f6e2d5;
+  --accent-foreground: #7f381d;
+
+  --destructive: #c94a3a;
   --destructive-foreground: #ffffff;
-  --border: rgba(0, 0, 0, 0.1);
+
+  --border: rgba(42, 19, 11, 0.09);
   --input: transparent;
-  --input-background: #f3f3f5;
-  --switch-background: #cbced4;
+  --input-background: #ffffff;
+  --switch-background: #d2c5ac;
+
   --font-weight-medium: 500;
   --font-weight-normal: 400;
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: #030213;
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+
+  --ring: rgba(193, 95, 54, 0.5);
+
+  --chart-1: #c15f36;   /* primary */
+  --chart-2: #9f6436;   /* secondary */
+  --chart-3: #c59818;   /* accent */
+  --chart-4: #d5814f;   /* primary-400 */
+  --chart-5: #b88158;   /* secondary-400 */
+
+  --radius: 0.75rem;
+
+  --sidebar: #faf8f3;
+  --sidebar-foreground: #1a1510;
+  --sidebar-primary: #c15f36;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f3efe6;
+  --sidebar-accent-foreground: #1a1510;
+  --sidebar-border: rgba(42, 19, 11, 0.08);
+  --sidebar-ring: rgba(193, 95, 54, 0.5);
+
+  /* Design tokens for premium treatments */
+  --color-primary-50: #fbf2ed;
+  --color-primary-100: #f6e2d5;
+  --color-primary-200: #edc3a6;
+  --color-primary-300: #e2a278;
+  --color-primary-400: #d5814f;
+  --color-primary-500: #c15f36;
+  --color-primary-600: #a44a27;
+  --color-primary-700: #7f381d;
+  --color-accent-300: #ecca59;
+  --color-accent-500: #c59818;
+  --color-accent-600: #9e7912;
+  --color-secondary-300: #cca281;
+  --color-secondary-500: #9f6436;
+  --color-secondary-700: #603c20;
+  --color-ink-warm-300: #d2c5ac;
+  --color-ink-warm-700: #4c3f31;
+  --color-ink-warm-800: #2d261d;
+  --color-ink-warm-900: #1a1510;
+
+  /* Editorial font stack */
+  --font-serif: "Fraunces", "Tiempos Headline", "Charter", "Georgia", "Cambria", "Times New Roman", serif;
+  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.145 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.145 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
-  --border: oklch(0.269 0 0);
-  --input: oklch(0.269 0 0);
-  --ring: oklch(0.439 0 0);
-  --font-weight-medium: 500;
-  --font-weight-normal: 400;
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(0.269 0 0);
-  --sidebar-ring: oklch(0.439 0 0);
+  --background: #100d0a;           /* deep warm ink */
+  --foreground: #f3efe6;
+  --card: #1a1510;
+  --card-foreground: #f3efe6;
+  --popover: #1a1510;
+  --popover-foreground: #f3efe6;
+
+  --primary: #d5814f;              /* terracotta 400 in dark */
+  --primary-foreground: #1a0a06;
+
+  --secondary: #2d261d;
+  --secondary-foreground: #f3efe6;
+
+  --muted: #2d261d;
+  --muted-foreground: #b09d7e;
+
+  --accent: #2d261d;
+  --accent-foreground: #edc3a6;
+
+  --destructive: #e06b5a;
+  --destructive-foreground: #1a0a06;
+
+  --border: rgba(243, 239, 230, 0.08);
+  --input: #2d261d;
+  --input-background: #1a1510;
+  --switch-background: #4c3f31;
+
+  --ring: rgba(213, 129, 79, 0.55);
+
+  --chart-1: #d5814f;
+  --chart-2: #b88158;
+  --chart-3: #e3b428;
+  --chart-4: #c15f36;
+  --chart-5: #9f6436;
+
+  --sidebar: #1a1510;
+  --sidebar-foreground: #f3efe6;
+  --sidebar-primary: #d5814f;
+  --sidebar-primary-foreground: #1a0a06;
+  --sidebar-accent: #2d261d;
+  --sidebar-accent-foreground: #f3efe6;
+  --sidebar-border: rgba(243, 239, 230, 0.08);
+  --sidebar-ring: rgba(213, 129, 79, 0.55);
 }
 
 @theme inline {
@@ -119,6 +167,10 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+
+  --font-serif: var(--font-serif);
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
 }
 
 @layer base {
@@ -128,6 +180,10 @@
 
   body {
     @apply bg-background text-foreground;
+    font-family: var(--font-sans);
+    font-feature-settings: "ss01", "cv11";
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 }
 
@@ -163,7 +219,7 @@
     p {
       font-size: var(--text-base);
       font-weight: var(--font-weight-normal);
-      line-height: 1.5;
+      line-height: 1.55;
     }
 
     label {
@@ -190,43 +246,257 @@ html {
   font-size: var(--font-size);
 }
 
-/* ReactFlow Dark Theme */
-.dark .react-flow {
-  background-color: oklch(0.145 0 0);
+/* Editorial serif utility — use sparingly for display moments */
+.font-serif {
+  font-family: var(--font-serif);
+  font-feature-settings: "ss01", "cv11", "liga", "dlig";
+  font-variation-settings: "SOFT" 30, "WONK" 0, "opsz" 96;
+  letter-spacing: -0.02em;
 }
 
+/* Film-grain overlay */
+.grain::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.28;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.55 0 0 0 0 0.35 0 0 0 0 0.18 0 0 0 0.9 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size: 180px 180px;
+}
+
+.dark .grain::before {
+  opacity: 0.14;
+  mix-blend-mode: soft-light;
+}
+
+/* Warm radial mesh — for hero/empty-state backdrops */
+.mesh-warm {
+  background-image:
+    radial-gradient(at 18% 22%, color-mix(in oklab, var(--color-primary-300) 55%, transparent) 0, transparent 55%),
+    radial-gradient(at 82% 12%, color-mix(in oklab, var(--color-accent-300) 45%, transparent) 0, transparent 50%),
+    radial-gradient(at 75% 88%, color-mix(in oklab, var(--color-secondary-300) 40%, transparent) 0, transparent 55%),
+    radial-gradient(at 12% 85%, color-mix(in oklab, var(--color-primary-200) 55%, transparent) 0, transparent 55%);
+}
+
+.dark .mesh-warm {
+  background-image:
+    radial-gradient(at 18% 22%, color-mix(in oklab, var(--color-primary-700) 50%, transparent) 0, transparent 55%),
+    radial-gradient(at 82% 12%, color-mix(in oklab, var(--color-accent-600) 45%, transparent) 0, transparent 50%),
+    radial-gradient(at 75% 88%, color-mix(in oklab, var(--color-secondary-700) 45%, transparent) 0, transparent 55%),
+    radial-gradient(at 12% 85%, color-mix(in oklab, var(--color-primary-700) 55%, transparent) 0, transparent 55%);
+}
+
+/* Dotted texture — for subtle depth */
+.surface-dotted {
+  background-image: radial-gradient(circle, color-mix(in oklab, var(--color-ink-warm-300) 70%, transparent) 1px, transparent 1px);
+  background-size: 22px 22px;
+}
+
+.dark .surface-dotted {
+  background-image: radial-gradient(circle, color-mix(in oklab, var(--color-ink-warm-700) 80%, transparent) 1px, transparent 1px);
+}
+
+/* Premium card — stacked soft shadow, lifts on hover */
+.card-premium {
+  background-color: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.65) inset,
+    0 1px 3px rgba(42, 19, 11, 0.05),
+    0 8px 24px -12px rgba(42, 19, 11, 0.1),
+    0 24px 48px -24px rgba(42, 19, 11, 0.08);
+  transition: box-shadow 0.3s ease, transform 0.3s ease, border-color 0.3s ease;
+}
+
+.card-premium:hover {
+  transform: translateY(-1px);
+  border-color: var(--color-primary-300);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.7) inset,
+    0 2px 4px rgba(193, 95, 54, 0.08),
+    0 14px 30px -14px rgba(193, 95, 54, 0.18),
+    0 34px 60px -28px rgba(42, 19, 11, 0.14);
+}
+
+.dark .card-premium {
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.04) inset,
+    0 1px 3px rgba(0, 0, 0, 0.5),
+    0 10px 28px -14px rgba(0, 0, 0, 0.6),
+    0 28px 56px -28px rgba(0, 0, 0, 0.5);
+}
+
+.dark .card-premium:hover {
+  border-color: var(--color-primary-700);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.05) inset,
+    0 2px 6px rgba(193, 95, 54, 0.18),
+    0 16px 36px -14px rgba(193, 95, 54, 0.28),
+    0 36px 64px -28px rgba(0, 0, 0, 0.65);
+}
+
+/* Terracotta → amber gradient ink — for display headings */
+.ink-gradient {
+  background: linear-gradient(110deg, var(--color-primary-600) 0%, var(--color-primary-500) 35%, var(--color-accent-600) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.dark .ink-gradient {
+  background: linear-gradient(110deg, #e2a278 0%, #ecca59 70%, #f3dd91 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+/* Hairline gradient divider */
+.divider-warm {
+  height: 1px;
+  background: linear-gradient(to right, transparent, var(--color-ink-warm-300), transparent);
+}
+
+.dark .divider-warm {
+  background: linear-gradient(to right, transparent, var(--color-ink-warm-700), transparent);
+}
+
+/* Premium shadow helpers for buttons */
+.shadow-premium {
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.15) inset,
+    0 4px 12px -4px rgba(0, 0, 0, 0.2),
+    0 12px 28px -8px rgba(193, 95, 54, 0.35);
+}
+
+.shadow-premium-hover:hover {
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.2) inset,
+    0 6px 16px -4px rgba(0, 0, 0, 0.25),
+    0 18px 36px -8px rgba(193, 95, 54, 0.5);
+}
+
+/* Custom scrollbar — warm */
+::-webkit-scrollbar {
+  width: 11px;
+  height: 11px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: color-mix(in oklab, var(--color-ink-warm-300) 80%, transparent);
+  border-radius: 6px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in oklab, var(--color-primary-400) 80%, transparent);
+  background-clip: padding-box;
+  border: 2px solid transparent;
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background: color-mix(in oklab, var(--color-ink-warm-700) 80%, transparent);
+  background-clip: padding-box;
+  border: 2px solid transparent;
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in oklab, var(--color-primary-500) 80%, transparent);
+  background-clip: padding-box;
+  border: 2px solid transparent;
+}
+
+/* ReactFlow theming — warm both light and dark */
+.react-flow {
+  background-color: var(--background);
+}
+
+.react-flow__background {
+  background-color: var(--background);
+}
+
+.react-flow__minimap {
+  background-color: var(--card);
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 14px -6px rgba(42, 19, 11, 0.1);
+}
+
+.react-flow__controls {
+  background-color: var(--card);
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.7) inset, 0 4px 14px -6px rgba(42, 19, 11, 0.1);
+  overflow: hidden;
+}
+
+.react-flow__controls-button {
+  background-color: var(--card);
+  color: var(--foreground);
+  border: none;
+  border-bottom: 1px solid var(--border);
+}
+
+.react-flow__controls-button:hover {
+  background-color: var(--muted);
+  color: var(--primary);
+}
+
+.react-flow__edge-path {
+  stroke: color-mix(in oklab, var(--color-primary-400) 60%, transparent);
+  stroke-width: 1.5;
+}
+
+.react-flow__handle {
+  background-color: var(--card);
+  border: 2px solid var(--color-primary-400);
+  width: 10px;
+  height: 10px;
+}
+
+.react-flow__handle.connectable:hover {
+  background-color: var(--color-primary-500);
+  border-color: var(--color-primary-600);
+}
+
+.dark .react-flow,
 .dark .react-flow__background {
-  background-color: oklch(0.145 0 0);
+  background-color: var(--background);
 }
 
 .dark .react-flow__minimap {
-  background-color: oklch(0.205 0 0);
+  background-color: var(--card);
 }
 
 .dark .react-flow__controls {
-  background-color: oklch(0.205 0 0);
-  box-shadow: 0 0 0 1px oklch(0.269 0 0);
+  background-color: var(--card);
+  box-shadow: 0 0 0 1px var(--border);
 }
 
 .dark .react-flow__controls-button {
-  background-color: oklch(0.269 0 0);
-  color: oklch(0.985 0 0);
-  border: none;
+  background-color: var(--card);
+  color: var(--foreground);
+  border-bottom-color: var(--border);
 }
 
 .dark .react-flow__controls-button:hover {
-  background-color: oklch(0.329 0 0);
+  background-color: var(--muted);
 }
 
 .dark .react-flow__edge-path {
-  stroke: oklch(0.5 0 0);
+  stroke: color-mix(in oklab, var(--color-primary-400) 50%, transparent);
 }
 
 .dark .react-flow__handle {
-  background-color: oklch(0.329 0 0);
-  border-color: oklch(0.5 0 0);
+  background-color: var(--card);
+  border-color: var(--color-primary-400);
 }
 
 .dark .react-flow__handle.connectable:hover {
-  background-color: oklch(0.438 0 0);
+  background-color: var(--color-primary-500);
 }

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8">
     <title>Loopi</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300..700&family=Inter:wght@300..700&family=JetBrains+Mono:wght@400..600&display=swap" rel="stylesheet">
   </head>
 
   <body>


### PR DESCRIPTION
  Rebrand the desktop app from cold neutral to warm editorial:                                                                                                    
  - Semantic tokens rewritten in index.css → every shadcn component rebrands at once
  - Fraunces serif at hero moments (header wordmark, Dashboard/Agents hero bands, empty states); Inter for dense UI                                               
  - New utilities: grain (SVG turbulence), mesh-warm, surface-dotted, card-premium, ink-gradient, shadow-premium                                                  
  - Dashboard + AgentsPanel hero bands with eyebrow chips and gradient headlines                                                                                  
  - AgentCard: gradient letter-mark, status hairline, premium shadow stack                                                                                        
  - Chat empty state refreshed with editorial copy                                                                                                                
  - ReactFlow re-themed (handles, edges, controls, minimap)                                                                                                       
  - Bump version to 1.10.0 
