### PR TITLE
Ux/scheduler cursors fontsize

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: 22
-
-      - name: Enable Corepack and install pnpm
-        run: corepack enable
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -47,13 +48,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: 22
-
-      - name: Enable Corepack and install pnpm
-        run: corepack enable
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -42,6 +42,14 @@ export default function App() {
           } else {
             root.classList.toggle("dark", settings.theme === "dark");
           }
+
+          const fontSizePx: Record<string, string> = {
+            small: "14px",
+            default: "16px",
+            large: "17.5px",
+            xlarge: "19px",
+          };
+          root.style.fontSize = fontSizePx[settings.fontSize ?? "default"] ?? "16px";
         }
       } catch (error) {
         console.error("Failed to load theme:", error);
@@ -118,7 +126,10 @@ export default function App() {
         <div className="flex h-16 items-center justify-between px-6">
           <div className="flex items-center gap-2.5">
             <div className="relative">
-              <div className="absolute inset-0 rounded-lg bg-primary/20 blur-md -z-10" aria-hidden />
+              <div
+                className="absolute inset-0 rounded-lg bg-primary/20 blur-md -z-10"
+                aria-hidden
+              />
               <img src={loopLogo} alt="Loopi" className="h-8 w-8 relative" />
             </div>
             <h1 className="font-serif text-xl tracking-tight">

--- a/src/components/AgentsPanel.tsx
+++ b/src/components/AgentsPanel.tsx
@@ -99,15 +99,21 @@ export function AgentsPanel({ onOpenWorkflow }: AgentsPanelProps) {
               Agents
             </span>
             <h2 className="font-serif text-3xl leading-[1.05] tracking-tight mb-2">
-              Goal‑driven workers that{" "}
-              <em className="not-italic ink-gradient">patch themselves</em>.
+              Goal‑driven workers that <em className="not-italic ink-gradient">patch themselves</em>
+              .
             </h2>
             <p className="text-sm text-muted-foreground leading-relaxed">
-              AI agents that execute tasks using workflows, APIs, and desktop controls. Reflection rewrites failing workflows in place.
+              AI agents that execute tasks using workflows, APIs, and desktop controls. Reflection
+              rewrites failing workflows in place.
             </p>
           </div>
           <div className="flex gap-2">
-            <Button variant="outline" size="sm" onClick={loadAgents} className="backdrop-blur bg-card/80">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={loadAgents}
+              className="backdrop-blur bg-card/80"
+            >
               <RefreshCw className="h-4 w-4 mr-1" />
               Refresh
             </Button>
@@ -130,7 +136,10 @@ export function AgentsPanel({ onOpenWorkflow }: AgentsPanelProps) {
         </div>
       ) : agents.length === 0 ? (
         <div className="relative overflow-hidden rounded-2xl border border-dashed border-border/70 py-20 text-center grain">
-          <div className="absolute inset-0 surface-dotted opacity-25 pointer-events-none" aria-hidden />
+          <div
+            className="absolute inset-0 surface-dotted opacity-25 pointer-events-none"
+            aria-hidden
+          />
           <div className="relative flex flex-col items-center">
             <div className="relative mb-5">
               <div className="absolute inset-0 bg-primary/30 blur-2xl rounded-full" aria-hidden />
@@ -141,8 +150,8 @@ export function AgentsPanel({ onOpenWorkflow }: AgentsPanelProps) {
             <h3 className="font-serif text-xl mb-2">No agents yet</h3>
             <p className="text-sm text-muted-foreground mb-6 max-w-md leading-relaxed">
               Create agents to automate complex tasks. Agents can run workflows, make API calls,
-              control your desktop, and more. You can also ask Loopi in the Chat tab to create agents
-              for you.
+              control your desktop, and more. You can also ask Loopi in the Chat tab to create
+              agents for you.
             </p>
             <Button
               onClick={() => setCreateOpen(true)}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1424,7 +1424,10 @@ export function Chat() {
       <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
         {messages.length === 0 && (
           <div className="relative flex items-center justify-center h-full grain overflow-hidden">
-            <div className="absolute inset-0 mesh-warm opacity-30 pointer-events-none" aria-hidden />
+            <div
+              className="absolute inset-0 mesh-warm opacity-30 pointer-events-none"
+              aria-hidden
+            />
             <div className="relative text-center space-y-4 max-w-md px-6">
               <div className="relative mx-auto w-16 h-16">
                 <div className="absolute inset-0 bg-primary/25 blur-2xl rounded-full" aria-hidden />

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -110,7 +110,10 @@ export function Dashboard({
       {/* Editorial header band */}
       <div className="relative overflow-hidden rounded-2xl border border-border/70 bg-card p-6 sm:p-8 grain">
         <div className="absolute inset-0 mesh-warm opacity-40 pointer-events-none" aria-hidden />
-        <div className="absolute inset-0 surface-dotted opacity-20 pointer-events-none" aria-hidden />
+        <div
+          className="absolute inset-0 surface-dotted opacity-20 pointer-events-none"
+          aria-hidden
+        />
         <div className="relative flex flex-col sm:flex-row sm:items-end sm:justify-between gap-5">
           <div className="max-w-xl">
             <span className="inline-flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.18em] text-primary mb-3">
@@ -118,8 +121,7 @@ export function Dashboard({
               Workspace
             </span>
             <h2 className="font-serif text-3xl sm:text-4xl leading-[1.05] tracking-tight mb-2">
-              Build what you want.{" "}
-              <em className="not-italic ink-gradient">Loopi runs it.</em>
+              Build what you want. <em className="not-italic ink-gradient">Loopi runs it.</em>
             </h2>
             <p className="text-sm text-muted-foreground leading-relaxed">
               {totalAutomations === 0
@@ -136,11 +138,21 @@ export function Dashboard({
               <Plus className="h-5 w-5 mr-2" />
               Add Automation
             </Button>
-            <Button onClick={handleImportAutomation} variant="outline" size="lg" className="backdrop-blur bg-card/80">
+            <Button
+              onClick={handleImportAutomation}
+              variant="outline"
+              size="lg"
+              className="backdrop-blur bg-card/80"
+            >
               <Upload className="h-5 w-5 mr-2" />
               Import
             </Button>
-            <Button onClick={() => setAiDialogOpen(true)} variant="outline" size="lg" className="backdrop-blur bg-card/80 group">
+            <Button
+              onClick={() => setAiDialogOpen(true)}
+              variant="outline"
+              size="lg"
+              className="backdrop-blur bg-card/80 group"
+            >
               <Sparkles className="h-5 w-5 mr-2 text-primary group-hover:rotate-12 transition-transform" />
               AI Generate
             </Button>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,5 +1,5 @@
-import type { AppSettings, Credential } from "@app-types/globals";
-import { FolderOpen, Key, Moon, Settings as SettingsIcon, Sparkles, Sun } from "lucide-react";
+import type { AppFontSize, AppSettings, Credential } from "@app-types/globals";
+import { FolderOpen, Key, Moon, Settings as SettingsIcon, Sparkles, Sun, Type } from "lucide-react";
 import { useEffect, useState } from "react";
 import { CredentialsManager } from "./CredentialsManager";
 import { Button } from "./ui/button";
@@ -24,9 +24,21 @@ const getCurrentTheme = (): "light" | "dark" | "system" => {
   return document.documentElement.classList.contains("dark") ? "dark" : "light";
 };
 
+const FONT_SIZE_PX: Record<AppFontSize, string> = {
+  small: "14px",
+  default: "16px",
+  large: "17.5px",
+  xlarge: "19px",
+};
+
+export const applyFontSize = (size: AppFontSize = "default") => {
+  document.documentElement.style.fontSize = FONT_SIZE_PX[size] ?? FONT_SIZE_PX.default;
+};
+
 export function Settings() {
   const [settings, setSettings] = useState<AppSettings>({
     theme: getCurrentTheme() as "light" | "dark" | "system",
+    fontSize: "default",
     enableNotifications: true,
     downloadPath: "",
   });
@@ -41,6 +53,7 @@ export function Settings() {
         if (savedSettings) {
           setSettings(savedSettings);
           applyTheme(savedSettings.theme);
+          applyFontSize(savedSettings.fontSize);
         }
       } catch (error) {
         console.error("Failed to load settings:", error);
@@ -66,6 +79,10 @@ export function Settings() {
   useEffect(() => {
     applyTheme(settings.theme);
   }, [settings.theme]);
+
+  useEffect(() => {
+    applyFontSize(settings.fontSize);
+  }, [settings.fontSize]);
 
   useEffect(() => {
     if (!loading) {
@@ -130,6 +147,42 @@ export function Settings() {
                         </div>
                       </SelectItem>
                       <SelectItem value="system">System</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div className="space-y-1">
+                    <Label htmlFor="fontSize" className="text-base flex items-center gap-2">
+                      <Type className="h-4 w-4" />
+                      Font Size
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Scales the entire application UI
+                    </p>
+                  </div>
+                  <Select
+                    value={settings.fontSize ?? "default"}
+                    onValueChange={(value: AppFontSize) => {
+                      setSettings({ ...settings, fontSize: value });
+                    }}
+                  >
+                    <SelectTrigger id="fontSize" className="w-40">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="small">
+                        <span className="text-[13px]">Small</span>
+                      </SelectItem>
+                      <SelectItem value="default">
+                        <span className="text-[15px]">Default</span>
+                      </SelectItem>
+                      <SelectItem value="large">
+                        <span className="text-[16px]">Large</span>
+                      </SelectItem>
+                      <SelectItem value="xlarge">
+                        <span className="text-[17px]">Extra Large</span>
+                      </SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/src/components/WorkflowScheduler.tsx
+++ b/src/components/WorkflowScheduler.tsx
@@ -4,9 +4,10 @@
  * Allows multiple schedules per workflow with different configurations
  */
 
+import type { Agent } from "@app-types/agent";
 import type { ScheduleType, StoredAutomation } from "@app-types/automation";
 import type { WorkflowSchedule } from "@app-types/globals";
-import { Calendar, Clock, PauseCircle, PlayCircle, Plus, Trash2 } from "lucide-react";
+import { Bot, Calendar, Clock, PauseCircle, PlayCircle, Plus, Trash2 } from "lucide-react";
 import React, { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ScheduleConfig } from "./automationBuilder/ScheduleConfig";
@@ -31,15 +32,16 @@ interface WorkflowSchedulerProps {
 
 export const WorkflowScheduler: React.FC<WorkflowSchedulerProps> = ({ automations }) => {
   const [schedules, setSchedules] = useState<WorkflowSchedule[]>([]);
+  const [agentSchedules, setAgentSchedules] = useState<Agent[]>([]);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string>("");
   const [newSchedule, setNewSchedule] = useState<ScheduleType>({ type: "manual" });
   const [newEnabled, setNewEnabled] = useState(true);
   const [newHeadless, setNewHeadless] = useState(true);
 
-  // Load schedules on mount
   useEffect(() => {
     loadSchedules();
+    loadAgentSchedules();
   }, []);
 
   const loadSchedules = async () => {
@@ -50,6 +52,15 @@ export const WorkflowScheduler: React.FC<WorkflowSchedulerProps> = ({ automation
       }
     } catch (error) {
       console.error("Failed to load schedules:", error);
+    }
+  };
+
+  const loadAgentSchedules = async () => {
+    try {
+      const allAgents = (await window.electronAPI?.agents.list()) ?? [];
+      setAgentSchedules(allAgents.filter((a) => a.schedule && a.schedule.type !== "manual"));
+    } catch (error) {
+      console.error("Failed to load agent schedules:", error);
     }
   };
 
@@ -121,6 +132,27 @@ export const WorkflowScheduler: React.FC<WorkflowSchedulerProps> = ({ automation
       case "manual":
         return "Manual";
     }
+  };
+
+  const describeAgentSchedule = (schedule: Agent["schedule"]): string => {
+    if (!schedule) return "Manual";
+    if (schedule.type === "interval" && schedule.intervalMinutes) {
+      return `Every ${schedule.intervalMinutes} minutes`;
+    }
+    if (schedule.type === "cron" && schedule.expression) {
+      return `Cron: ${schedule.expression}`;
+    }
+    if (schedule.type === "once" && schedule.datetime) {
+      return `Once at ${new Date(schedule.datetime).toLocaleString()}`;
+    }
+    return schedule.type;
+  };
+
+  const workflowNamesFor = (workflowIds: string[]): string => {
+    if (!workflowIds || workflowIds.length === 0) return "—";
+    return workflowIds
+      .map((id) => automations.find((a) => a.id === id)?.name ?? `Workflow ${id}`)
+      .join(", ");
   };
 
   return (
@@ -218,8 +250,8 @@ export const WorkflowScheduler: React.FC<WorkflowSchedulerProps> = ({ automation
             <Calendar className="h-16 w-16 text-muted-foreground mb-4" />
             <h3 className="text-xl font-semibold mb-2">No Workflow Schedules Yet</h3>
             <p className="text-muted-foreground text-center max-w-md mb-6">
-              This tab schedules workflows directly. Agent schedules live on each agent and are
-              managed in the Agents tab — they won't appear here.
+              This tab schedules workflows directly. Schedules attached to agents appear below in a
+              read-only view — manage them from the Agents tab.
             </p>
             <Button onClick={() => setIsDialogOpen(true)}>
               <Plus className="h-4 w-4 mr-2" />
@@ -285,6 +317,75 @@ export const WorkflowScheduler: React.FC<WorkflowSchedulerProps> = ({ automation
                           <Trash2 className="h-4 w-4 text-destructive" />
                         </Button>
                       </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Scheduled via Agents (read-only) */}
+      {agentSchedules.length > 0 && (
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Bot className="h-4 w-4 text-primary" />
+              <CardTitle>Scheduled via Agents</CardTitle>
+            </div>
+            <CardDescription>
+              {agentSchedules.length} agent{agentSchedules.length !== 1 ? "s" : ""} running on a
+              schedule. Manage these in the Agents tab.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Workflow</TableHead>
+                  <TableHead>Agent</TableHead>
+                  <TableHead>Schedule</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Last Run</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {agentSchedules.map((agent) => (
+                  <TableRow key={agent.id}>
+                    <TableCell className="font-medium">
+                      {workflowNamesFor(agent.workflowIds)}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-col">
+                        <span className="text-sm">{agent.name}</span>
+                        <span className="text-xs text-muted-foreground">{agent.role}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Clock className="h-4 w-4 text-muted-foreground" />
+                        {describeAgentSchedule(agent.schedule)}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={agent.status === "running" ? "default" : "secondary"}
+                        className={
+                          agent.status === "failed"
+                            ? "bg-red-100 text-red-700 dark:bg-red-950/50 dark:text-red-300"
+                            : undefined
+                        }
+                      >
+                        {agent.status === "running"
+                          ? "Running"
+                          : agent.status === "failed"
+                            ? "Failed"
+                            : "Active"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {agent.lastRunAt ? new Date(agent.lastRunAt).toLocaleString() : "Never"}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/components/agents/AgentCard.tsx
+++ b/src/components/agents/AgentCard.tsx
@@ -17,8 +17,7 @@ const STATUS_COLORS: Record<string, string> = {
     "bg-emerald-100 text-emerald-700 border-emerald-200/80 dark:bg-emerald-950/50 dark:text-emerald-300 dark:border-emerald-900/60",
   running:
     "bg-emerald-100 text-emerald-700 border-emerald-200/80 dark:bg-emerald-950/50 dark:text-emerald-300 dark:border-emerald-900/60",
-  stopped:
-    "bg-muted text-muted-foreground border-border",
+  stopped: "bg-muted text-muted-foreground border-border",
   failed:
     "bg-red-100 text-red-700 border-red-200/80 dark:bg-red-950/50 dark:text-red-300 dark:border-red-900/60",
 };
@@ -52,7 +51,10 @@ export function AgentCard({ agent, onStart, onStop, onDelete, onClick }: AgentCa
       onClick={() => onClick(agent)}
     >
       {status === "running" && (
-        <div className="absolute top-0 inset-x-0 h-px bg-gradient-to-r from-transparent via-emerald-500 to-transparent" aria-hidden />
+        <div
+          className="absolute top-0 inset-x-0 h-px bg-gradient-to-r from-transparent via-emerald-500 to-transparent"
+          aria-hidden
+        />
       )}
       <div className="flex items-start justify-between mb-3 gap-2">
         <div className="flex items-start gap-3 min-w-0 flex-1">
@@ -64,7 +66,10 @@ export function AgentCard({ agent, onStart, onStop, onDelete, onClick }: AgentCa
             <p className="text-xs text-muted-foreground truncate mt-0.5">{agent.role}</p>
           </div>
         </div>
-        <Badge variant="outline" className={`text-[10px] font-medium uppercase tracking-wider border ${STATUS_COLORS[status] || ""}`}>
+        <Badge
+          variant="outline"
+          className={`text-[10px] font-medium uppercase tracking-wider border ${STATUS_COLORS[status] || ""}`}
+        >
           {status === "running" && (
             <span className="mr-1 inline-block w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
           )}

--- a/src/index.css
+++ b/src/index.css
@@ -6,8 +6,8 @@
   --font-size: 14.5px;
 
   /* Warm editorial palette — matches loopi.site */
-  --background: #faf8f3;           /* parchment */
-  --foreground: #1a1510;           /* warm ink */
+  --background: #faf8f3; /* parchment */
+  --foreground: #1a1510; /* warm ink */
   --card: #ffffff;
   --card-foreground: #1a1510;
   --popover: #ffffff;
@@ -39,11 +39,11 @@
 
   --ring: rgba(193, 95, 54, 0.5);
 
-  --chart-1: #c15f36;   /* primary */
-  --chart-2: #9f6436;   /* secondary */
-  --chart-3: #c59818;   /* accent */
-  --chart-4: #d5814f;   /* primary-400 */
-  --chart-5: #b88158;   /* secondary-400 */
+  --chart-1: #c15f36; /* primary */
+  --chart-2: #9f6436; /* secondary */
+  --chart-3: #c59818; /* accent */
+  --chart-4: #d5814f; /* primary-400 */
+  --chart-5: #b88158; /* secondary-400 */
 
   --radius: 0.75rem;
 
@@ -77,20 +77,25 @@
   --color-ink-warm-900: #1a1510;
 
   /* Editorial font stack */
-  --font-serif: "Fraunces", "Tiempos Headline", "Charter", "Georgia", "Cambria", "Times New Roman", serif;
-  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
-  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --font-serif:
+    "Fraunces", "Tiempos Headline", "Charter", "Georgia", "Cambria", "Times New Roman", serif;
+  --font-sans:
+    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji";
+  --font-mono:
+    "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono",
+    monospace;
 }
 
 .dark {
-  --background: #100d0a;           /* deep warm ink */
+  --background: #100d0a; /* deep warm ink */
   --foreground: #f3efe6;
   --card: #1a1510;
   --card-foreground: #f3efe6;
   --popover: #1a1510;
   --popover-foreground: #f3efe6;
 
-  --primary: #d5814f;              /* terracotta 400 in dark */
+  --primary: #d5814f; /* terracotta 400 in dark */
   --primary-foreground: #1a0a06;
 
   --secondary: #2d261d;
@@ -185,6 +190,20 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
+
+  /* Tailwind v4 dropped the implicit `cursor: pointer` from preflight.
+     Restore it for interactive controls so buttons, tab triggers,
+     dropdowns, switches, and any `role="button"` element feel clickable. */
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]),
+  [role="tab"]:not([aria-disabled="true"]),
+  [role="menuitem"]:not([aria-disabled="true"]),
+  [role="option"]:not([aria-disabled="true"]),
+  [role="switch"]:not([aria-disabled="true"]),
+  [role="checkbox"]:not([aria-disabled="true"]),
+  summary {
+    cursor: pointer;
+  }
 }
 
 /**
@@ -250,7 +269,10 @@ html {
 .font-serif {
   font-family: var(--font-serif);
   font-feature-settings: "ss01", "cv11", "liga", "dlig";
-  font-variation-settings: "SOFT" 30, "WONK" 0, "opsz" 96;
+  font-variation-settings:
+    "SOFT" 30,
+    "WONK" 0,
+    "opsz" 96;
   letter-spacing: -0.02em;
 }
 
@@ -274,28 +296,68 @@ html {
 /* Warm radial mesh — for hero/empty-state backdrops */
 .mesh-warm {
   background-image:
-    radial-gradient(at 18% 22%, color-mix(in oklab, var(--color-primary-300) 55%, transparent) 0, transparent 55%),
-    radial-gradient(at 82% 12%, color-mix(in oklab, var(--color-accent-300) 45%, transparent) 0, transparent 50%),
-    radial-gradient(at 75% 88%, color-mix(in oklab, var(--color-secondary-300) 40%, transparent) 0, transparent 55%),
-    radial-gradient(at 12% 85%, color-mix(in oklab, var(--color-primary-200) 55%, transparent) 0, transparent 55%);
+    radial-gradient(
+      at 18% 22%,
+      color-mix(in oklab, var(--color-primary-300) 55%, transparent) 0,
+      transparent 55%
+    ),
+    radial-gradient(
+      at 82% 12%,
+      color-mix(in oklab, var(--color-accent-300) 45%, transparent) 0,
+      transparent 50%
+    ),
+    radial-gradient(
+      at 75% 88%,
+      color-mix(in oklab, var(--color-secondary-300) 40%, transparent) 0,
+      transparent 55%
+    ),
+    radial-gradient(
+      at 12% 85%,
+      color-mix(in oklab, var(--color-primary-200) 55%, transparent) 0,
+      transparent 55%
+    );
 }
 
 .dark .mesh-warm {
   background-image:
-    radial-gradient(at 18% 22%, color-mix(in oklab, var(--color-primary-700) 50%, transparent) 0, transparent 55%),
-    radial-gradient(at 82% 12%, color-mix(in oklab, var(--color-accent-600) 45%, transparent) 0, transparent 50%),
-    radial-gradient(at 75% 88%, color-mix(in oklab, var(--color-secondary-700) 45%, transparent) 0, transparent 55%),
-    radial-gradient(at 12% 85%, color-mix(in oklab, var(--color-primary-700) 55%, transparent) 0, transparent 55%);
+    radial-gradient(
+      at 18% 22%,
+      color-mix(in oklab, var(--color-primary-700) 50%, transparent) 0,
+      transparent 55%
+    ),
+    radial-gradient(
+      at 82% 12%,
+      color-mix(in oklab, var(--color-accent-600) 45%, transparent) 0,
+      transparent 50%
+    ),
+    radial-gradient(
+      at 75% 88%,
+      color-mix(in oklab, var(--color-secondary-700) 45%, transparent) 0,
+      transparent 55%
+    ),
+    radial-gradient(
+      at 12% 85%,
+      color-mix(in oklab, var(--color-primary-700) 55%, transparent) 0,
+      transparent 55%
+    );
 }
 
 /* Dotted texture — for subtle depth */
 .surface-dotted {
-  background-image: radial-gradient(circle, color-mix(in oklab, var(--color-ink-warm-300) 70%, transparent) 1px, transparent 1px);
+  background-image: radial-gradient(
+    circle,
+    color-mix(in oklab, var(--color-ink-warm-300) 70%, transparent) 1px,
+    transparent 1px
+  );
   background-size: 22px 22px;
 }
 
 .dark .surface-dotted {
-  background-image: radial-gradient(circle, color-mix(in oklab, var(--color-ink-warm-700) 80%, transparent) 1px, transparent 1px);
+  background-image: radial-gradient(
+    circle,
+    color-mix(in oklab, var(--color-ink-warm-700) 80%, transparent) 1px,
+    transparent 1px
+  );
 }
 
 /* Premium card — stacked soft shadow, lifts on hover */
@@ -308,7 +370,10 @@ html {
     0 1px 3px rgba(42, 19, 11, 0.05),
     0 8px 24px -12px rgba(42, 19, 11, 0.1),
     0 24px 48px -24px rgba(42, 19, 11, 0.08);
-  transition: box-shadow 0.3s ease, transform 0.3s ease, border-color 0.3s ease;
+  transition:
+    box-shadow 0.3s ease,
+    transform 0.3s ease,
+    border-color 0.3s ease;
 }
 
 .card-premium:hover {
@@ -340,7 +405,12 @@ html {
 
 /* Terracotta → amber gradient ink — for display headings */
 .ink-gradient {
-  background: linear-gradient(110deg, var(--color-primary-600) 0%, var(--color-primary-500) 35%, var(--color-accent-600) 100%);
+  background: linear-gradient(
+    110deg,
+    var(--color-primary-600) 0%,
+    var(--color-primary-500) 35%,
+    var(--color-accent-600) 100%
+  );
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
@@ -431,7 +501,9 @@ html {
 .react-flow__controls {
   background-color: var(--card);
   border-radius: 0.5rem;
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.7) inset, 0 4px 14px -6px rgba(42, 19, 11, 0.1);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.7) inset,
+    0 4px 14px -6px rgba(42, 19, 11, 0.1);
   overflow: hidden;
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,10 @@
     <title>Loopi</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300..700&family=Inter:wght@300..700&family=JetBrains+Mono:wght@400..600&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300..700&family=Inter:wght@300..700&family=JetBrains+Mono:wght@400..600&display=swap"
+      rel="stylesheet"
+    >
   </head>
 
   <body>

--- a/src/main/settingsStore.ts
+++ b/src/main/settingsStore.ts
@@ -18,12 +18,14 @@ function getDefaultSettings(): AppSettings {
     const { app } = require("electron");
     return {
       theme: "light",
+      fontSize: "default",
       enableNotifications: true,
       downloadPath: app.getPath("downloads"),
     };
   } catch {
     return {
       theme: "light",
+      fontSize: "default",
       enableNotifications: true,
     };
   }

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -107,8 +107,11 @@ export interface Credential {
   data: Record<string, string>;
 }
 
+export type AppFontSize = "small" | "default" | "large" | "xlarge";
+
 export interface AppSettings {
   theme: "light" | "dark" | "system";
+  fontSize?: AppFontSize;
   enableNotifications: boolean;
   downloadPath?: string;
   debugMode?: boolean;


### PR DESCRIPTION
## Summary

- WorkflowScheduler: render a read-only "Scheduled via Agents" card that lists every agent with a non-manual schedule (workflow name, agent, schedule, status, last run). Lifecycle stays in the Agents tab; this is purely visibility. Empty-state copy updated to reflect the new behaviour.

- Restore cursor: pointer globally for buttons, [role=tab|menuitem|option| switch|checkbox|button], Tailwind v4 dropped the v3 preflight rule, leaving most clickables with the default arrow. Fixed via one rule in index.css — no per-component edits.
  
- Settings → Appearance: new Font Size control with four tiers (Small / Default / Large / Extra Large). Sets html { font-size: … } so all rem-based Tailwind sizes scale together. Persisted in AppSettings, re-applied on startup alongside theme.
