### PR TITLE
fix: Windows PowerShell shell, OS-aware prompts, Claude sessions, instant dashboard refresh

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -79,15 +79,15 @@ export default function App() {
     }
   }, []);
 
-  // Refresh when Telegram bot creates a workflow or agent
+  // Refresh dashboard when Chat or Telegram bot creates a workflow
   useEffect(() => {
+    const onWorkflow = () => loadSavedTrees();
+    window.addEventListener("loopi:workflowSaved", onWorkflow);
     window.electronAPI?.telegram.onWorkflowSaved(() => {
       loadSavedTrees();
       toast.success("New workflow created via Telegram");
     });
-    window.electronAPI?.telegram.onAgentCreated(() => {
-      toast.success("New agent created via Telegram");
-    });
+    return () => window.removeEventListener("loopi:workflowSaved", onWorkflow);
   }, []);
 
   useEffect(() => {

--- a/src/components/AgentsPanel.tsx
+++ b/src/components/AgentsPanel.tsx
@@ -34,6 +34,16 @@ export function AgentsPanel({ onOpenWorkflow }: AgentsPanelProps) {
     loadAgents();
   }, [loadAgents]);
 
+  // Refresh when Chat or Telegram bot creates an agent
+  useEffect(() => {
+    window.addEventListener("loopi:agentCreated", loadAgents);
+    window.electronAPI?.telegram.onAgentCreated(() => {
+      loadAgents();
+      toast.success("New agent created via Telegram");
+    });
+    return () => window.removeEventListener("loopi:agentCreated", loadAgents);
+  }, [loadAgents]);
+
   const handleCreate = async (
     config: Parameters<NonNullable<typeof window.electronAPI>["agents"]["create"]>[0]
   ) => {

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -11,6 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@components/ui/select";
+import { buildPlatformShellNote } from "@utils/platformPrompt";
 import {
   AlertCircle,
   ArrowUp,
@@ -54,22 +55,43 @@ const PROVIDER_DEFAULTS: Record<Provider, { model: string; baseUrl: string; labe
   "claude-code": { model: "claude", baseUrl: "", label: "Claude Code" },
 };
 
-function buildChatSystemPrompt(isWindows: boolean): string {
-  const shellNote = isWindows
-    ? `## Platform: Windows
-run-command uses cmd.exe (NOT PowerShell). Use cmd.exe syntax only.
-- Open apps: \`start notepad.exe\`, \`start "" calc.exe\`, \`start "" "C:\\\\Windows\\\\System32\\\\mspaint.exe"\`
-- Create dirs: \`mkdir C:\\\\path\\\\to\\\\dir\`
-- Write files: \`echo text > file.txt\`
-- Do NOT use: \`Start-Process\`, \`Write-Host\`, \`$env:\`, \`New-Object\`, or ANY PowerShell syntax
-- Do NOT chain commands with \`;\` — use \`&&\` or separate run-command blocks
-- To type text into an open app: create a workflow with a \`desktopKeyboard\` step (type: "desktopKeyboard", text: "Hello world") — do NOT try to do it via run-command
-`
-    : `## Platform: Linux/macOS
-run-command uses /bin/sh.
-- Notifications: \`notify-send "Title" "Body"\` (Linux) or \`osascript -e 'display notification "Body" with title "Title"'\` (macOS)
-- Open apps: \`xdg-open file\` (Linux) / \`open -a "TextEdit"\` (macOS)
-`;
+function buildChatSystemPrompt(platform: string): string {
+  const shellNote = buildPlatformShellNote(platform);
+  const isWindows = platform === "win32";
+  const isMac = platform === "darwin";
+
+  // Pre-built per-OS example snippets — use template literals so single quotes need no escaping
+  const exForEachOutput = isWindows
+    ? `{ "type": "systemCommand", "command": "Write-Host \\"{{title}}\\"", "description": "Output title" }`
+    : isMac
+      ? `{ "type": "systemCommand", "command": "osascript -e 'display notification \\"{{title}}\\" with title \\"Loopi\\"'", "description": "Notify" }`
+      : `{ "type": "systemCommand", "command": "notify-send \\"{{title}}\\"", "description": "Notify" }`;
+
+  const exDesktopNotif = isWindows
+    ? "Use PowerShell: `Write-Host '{{body}}'` or `Out-File` to write to a file. notify-send is not available on Windows."
+    : isMac
+      ? 'Use systemCommand with osascript: `osascript -e \'display notification "{{body}}" with title "Loopi"\'`'
+      : 'Use systemCommand with notify-send: `notify-send "Title" "{{body}}"`. Double quotes around `{{var}}`, not single.';
+
+  const exNewsNotify = isWindows
+    ? `{ "type": "systemCommand", "command": "Write-Host \\"{{newsTitle}} — {{newsUrl}}\\"", "description": "Output news" }`
+    : isMac
+      ? `{ "type": "systemCommand", "command": "osascript -e 'display notification \\"{{newsUrl}}\\" with title \\"{{newsTitle}}\\"'", "description": "Send desktop notification" }`
+      : `{ "type": "systemCommand", "command": "notify-send -i info \\"Tech News\\" \\"{{newsTitle}} — {{newsUrl}}\\"", "description": "Send desktop notification" }`;
+
+  const exRunCmd = isWindows
+    ? `{ "action": "run-command", "command": "Start-Process notepad", "description": "Open Notepad" }`
+    : isMac
+      ? `{ "action": "run-command", "command": "open -a TextEdit", "description": "Open TextEdit" }`
+      : `{ "action": "run-command", "command": "notify-send \\"Hello\\" \\"World\\"", "description": "Send notification" }`;
+
+  const exMkdir = isWindows
+    ? `{ "action": "run-command", "command": "New-Item -ItemType Directory -Force \\"$env:TEMP\\\\loopi-test\\"", "description": "Create test folder" }`
+    : `{ "action": "run-command", "command": "mkdir -p ~/loopi-test", "description": "Create test folder" }`;
+
+  const exWriteFile = isWindows
+    ? `{ "action": "run-command", "command": "Set-Content \\"$env:TEMP\\\\loopi-test\\\\out.txt\\" \\"hello\\"", "description": "Write file" }`
+    : `{ "action": "run-command", "command": "echo hello > ~/loopi-test/out.txt", "description": "Write file" }`;
 
   return `You are Loopi, a helpful AI assistant integrated into the Loopi automation platform.
 Loopi is a visual browser & desktop automation tool with full desktop control (mouse, keyboard, CLI, browser).
@@ -116,7 +138,7 @@ Correct flat layout example:
   { "type": "forEach", "arrayVariable": "stories", "itemVariable": "story", "description": "Loop stories" },
   { "type": "jsonParse", "sourceVariable": "story", "path": "title", "storeKey": "title", "description": "Title" },
   { "type": "variableConditional", "variableConditionType": "variableExists", "variableName": "title", "description": "If title present" },
-  ${isWindows ? '{ "type": "systemCommand", "command": "echo {{title}}", "description": "Output title" }' : '{ "type": "systemCommand", "command": "notify-send \\"{{title}}\\"", "description": "Notify" }'}
+  ${exForEachOutput}
 ]
 \`\`\`
 Do NOT wrap the body steps inside a \`steps: [...]\` property of the forEach/conditional node.
@@ -158,7 +180,7 @@ Variable substitutions ({{var}}) often contain characters that break shell quoti
 1. **NEVER create external scripts** (Python, Bash, etc.) and call them via systemCommand. All logic MUST be built using Loopi's native step types.
 2. **NEVER write files to \`~\`, \`~/.config/\`, \`/tmp\`, or anywhere else on the filesystem as part of workflow logic.** When an agent workflow needs to persist data between runs (dedup tracking, caches, state), use the per-agent folder exposed as \`{{agentDataDir}}\`. Loopi injects this variable at runtime — the folder is created per-agent and visible to the user in the agent detail UI.
 3. **For uniqueness/dedup tracking inside agent workflows**: Use \`{{agentDataDir}}/<filename>\` — e.g. \`{{agentDataDir}}/seen-ids.txt\`. NEVER use \`~/.config/loopi\` or any hand-rolled path.
-4. **For desktop notifications**: ${isWindows ? 'Use a systemCommand with `msg %username% "{{body}}"` or simply `echo {{body}}` to write to a file. On Windows notify-send is not available.' : 'Use systemCommand with notify-send directly — e.g. { "type": "systemCommand", "command": "notify-send \\"Title\\" \\"{{body}}\\"" }. Double quotes around `{{var}}`, not single.'}
+4. **For desktop notifications**: ${exDesktopNotif}
 5. **Workflows MUST be self-contained** — every step uses Loopi's built-in step types. No external dependencies, no pip install, no script files.
 
 ### Agent working directory — \`{{agentDataDir}}\`:
@@ -172,11 +194,7 @@ The user can open the agent detail view to inspect and edit these files. **Never
 { "type": "apiCall", "url": "https://hn.algolia.com/api/v1/search_by_date?tags=story&numericFilters=points>20", "method": "GET", "storeKey": "hnData", "description": "Fetch recent HN stories" },
 { "type": "jsonParse", "sourceVariable": "hnData", "path": "data.hits[0].title", "storeKey": "newsTitle", "description": "Extract first story title (data. prefix because apiCall wraps response)" },
 { "type": "jsonParse", "sourceVariable": "hnData", "path": "data.hits[0].url", "storeKey": "newsUrl", "description": "Extract first story URL" },
-${
-  isWindows
-    ? '{ "type": "systemCommand", "command": "echo {{newsTitle}} — {{newsUrl}}", "description": "Output news" }'
-    : '{ "type": "systemCommand", "command": "notify-send -i info \\"Tech News\\" \\"{{newsTitle}} — {{newsUrl}}\\"", "description": "Send desktop notification" }'
-}
+${exNewsNotify}
 \`\`\`
 
 ### Example — WRONG approaches (DO NOT do any of these):
@@ -244,11 +262,7 @@ You can execute system commands and run workflows directly from chat. This is ho
 ${shellNote}
 ### Run a shell command on the user's PC:
 \`\`\`loopi-action
-${
-  isWindows
-    ? '{ "action": "run-command", "command": "start notepad.exe", "description": "Open Notepad" }'
-    : '{ "action": "run-command", "command": "notify-send \\"Hello\\" \\"World\\"", "description": "Send notification" }'
-}
+${exRunCmd}
 \`\`\`
 
 ### Run a workflow by name:
@@ -258,18 +272,10 @@ ${
 
 ### Run multiple commands sequentially:
 \`\`\`loopi-action
-${
-  isWindows
-    ? '{ "action": "run-command", "command": "start notepad.exe", "description": "Open Notepad" }'
-    : '{ "action": "run-command", "command": "mkdir -p ~/loopi-test", "description": "Create test folder" }'
-}
+${exMkdir}
 \`\`\`
 \`\`\`loopi-action
-${
-  isWindows
-    ? '{ "action": "run-command", "command": "echo Hello > test.txt", "description": "Write file" }'
-    : '{ "action": "run-command", "command": "echo hello > ~/loopi-test/out.txt", "description": "Write file" }'
-}
+${exWriteFile}
 \`\`\`
 
 **CRITICAL: You have FULL access to the user's PC.** You can run commands, open apps, control the desktop — ANYTHING via run-command. When the user asks you to do something, DO IT using run-command blocks. NEVER say "I can't run commands" or ask the user to run commands themselves. You ARE the automation tool.
@@ -308,6 +314,7 @@ When the user asks to delete an agent or workflow, ALWAYS include the loopi-acti
 
 export function Chat() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [sessionId, setSessionId] = useState(() => `app-chat-${Date.now()}`);
   const [input, setInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
@@ -516,6 +523,7 @@ export function Chat() {
 
   const handleResetChat = () => {
     setMessages([]);
+    setSessionId(`app-chat-${Date.now()}`);
     window.electronAPI?.chat?.clear().catch(() => {
       /* ignore */
     });
@@ -541,7 +549,7 @@ export function Chat() {
       const apiMessages = [
         {
           role: "system" as const,
-          content: buildChatSystemPrompt(window.electronAPI?.system.platform === "win32"),
+          content: buildChatSystemPrompt(window.electronAPI?.system.platform ?? "linux"),
         },
         ...messages.map((m) => ({ role: m.role, content: m.content })),
         { role: "user" as const, content: userMessage.content },
@@ -554,6 +562,7 @@ export function Chat() {
         credentialId: config.credentialId,
         model: config.model,
         baseUrl: config.baseUrl,
+        ...(config.provider === "claude-code" ? { sessionId } : {}),
       });
 
       if (result.success && result.response) {
@@ -705,6 +714,7 @@ export function Chat() {
                 if (savedId) {
                   createdWorkflowIds[wfConfig.name] = automation.id;
                   toast.success(`Workflow "${wfConfig.name}" created! View it in the Dashboard.`);
+                  window.dispatchEvent(new CustomEvent("loopi:workflowSaved"));
                 }
               }
             } catch (parseErr) {
@@ -792,6 +802,7 @@ export function Chat() {
                 });
                 if (agent) {
                   toast.success(`Agent "${agent.name}" created! View it in the Agents tab.`);
+                  window.dispatchEvent(new CustomEvent("loopi:agentCreated"));
                 }
               }
             } catch (parseErr) {

--- a/src/main/claudeCodeWorker.ts
+++ b/src/main/claudeCodeWorker.ts
@@ -1,0 +1,338 @@
+import { createLogger } from "@utils/logger";
+import { execSync, spawn } from "child_process";
+import { existsSync } from "fs";
+import http from "http";
+
+const logger = createLogger("ClaudeCodeWorker");
+
+const WORKER_PORT_BASE = 19544;
+const CLAUDE_CLI_TIMEOUT_MS = 600_000;
+const CONNECT_TIMEOUT_MS = 5_000;
+const MAX_BACKOFF_MS = 30_000;
+
+interface Session {
+  claudeSessionId: string;
+  lastUsedAt: number;
+}
+
+class ClaudeCodeWorker {
+  private server: http.Server | null = null;
+  private port: number | null = null;
+  private sessions = new Map<string, Session>();
+  private claudePath: string | null = null;
+  private startPromise: Promise<void> | null = null;
+  private backoffMs = 1_000;
+
+  private resolveClaudePath(): string {
+    if (this.claudePath) return this.claudePath;
+
+    const isWindows = process.platform === "win32";
+    let claudePath = isWindows ? "claude.cmd" : "claude";
+
+    try {
+      const whichCmd = isWindows ? "where claude" : "which claude";
+      claudePath = execSync(whichCmd, { encoding: "utf-8" }).trim().split(/\r?\n/)[0];
+    } catch {
+      const candidates = isWindows
+        ? [
+            `${process.env.APPDATA}\\npm\\claude.cmd`,
+            `${process.env.APPDATA}\\npm\\claude`,
+            `${process.env.LOCALAPPDATA}\\npm\\claude.cmd`,
+          ]
+        : [
+            `${process.env.HOME}/.local/bin/claude`,
+            "/usr/local/bin/claude",
+            `${process.env.HOME}/.npm-global/bin/claude`,
+          ];
+      for (const c of candidates) {
+        if (existsSync(c)) {
+          claudePath = c;
+          break;
+        }
+      }
+    }
+
+    this.claudePath = claudePath;
+    return claudePath;
+  }
+
+  private makeEnv(): NodeJS.ProcessEnv {
+    const env = { ...process.env };
+    delete env.ANTHROPIC_API_KEY;
+    if (process.platform !== "win32" && !env.PATH?.includes(".local/bin")) {
+      env.PATH = `${process.env.HOME}/.local/bin:${env.PATH}`;
+    }
+    return env;
+  }
+
+  private runClaude(
+    extraArgs: string[],
+    prompt: string
+  ): Promise<{ text: string; claudeSessionId: string }> {
+    const claudePath = this.resolveClaudePath();
+    const env = this.makeEnv();
+
+    return new Promise((resolve, reject) => {
+      let timedOut = false;
+      const proc = spawn(claudePath, [...extraArgs, "--output-format", "json", "-p"], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env,
+      });
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        proc.kill("SIGTERM");
+      }, CLAUDE_CLI_TIMEOUT_MS);
+
+      let stdout = "";
+      let stderr = "";
+      proc.stdout.on("data", (d: Buffer) => (stdout += d.toString()));
+      proc.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
+
+      proc.on("error", (err) => {
+        clearTimeout(timer);
+        reject(new Error(err.message));
+      });
+
+      proc.on("close", (code) => {
+        clearTimeout(timer);
+        if (timedOut) {
+          logger.error("claude CLI timed out", { timeoutMs: CLAUDE_CLI_TIMEOUT_MS });
+          reject(
+            new Error(
+              `Claude CLI did not respond within ${Math.round(CLAUDE_CLI_TIMEOUT_MS / 1000)}s. Try a shorter prompt, or switch providers in Settings.`
+            )
+          );
+          return;
+        }
+        if (code !== 0) {
+          logger.error("claude CLI failed", { code, stdout, stderr });
+          reject(new Error(stderr.trim() || stdout.trim() || `claude exited with code ${code}`));
+          return;
+        }
+        try {
+          const parsed = JSON.parse(stdout.trim()) as {
+            result?: string;
+            session_id?: string;
+          };
+          resolve({
+            text: String(parsed.result ?? ""),
+            claudeSessionId: String(parsed.session_id ?? ""),
+          });
+        } catch {
+          resolve({ text: stdout.trim(), claudeSessionId: "" });
+        }
+      });
+
+      proc.stdin.write(prompt);
+      proc.stdin.end();
+    });
+  }
+
+  private async processChat(
+    appSessionId: string,
+    messages: Array<{ role: string; content: string }>
+  ): Promise<string> {
+    const session = this.sessions.get(appSessionId);
+    const systemMsgs = messages.filter((m) => m.role === "system");
+    const lastUser = [...messages].reverse().find((m) => m.role === "user");
+    if (!lastUser) throw new Error("No user message in request");
+
+    let args: string[];
+    let prompt: string;
+
+    if (session?.claudeSessionId) {
+      // Existing session — only send the new user message; claude CLI owns the history
+      args = ["--resume", session.claudeSessionId];
+      prompt = lastUser.content;
+    } else {
+      // First turn — include system prompt so claude is primed correctly
+      args = [];
+      const parts: string[] = [];
+      if (systemMsgs.length > 0) {
+        parts.push(systemMsgs.map((m) => m.content).join("\n"));
+      }
+      parts.push(lastUser.content);
+      prompt = parts.join("\n\n");
+    }
+
+    const { text, claudeSessionId } = await this.runClaude(args, prompt);
+
+    if (claudeSessionId) {
+      this.sessions.set(appSessionId, { claudeSessionId, lastUsedAt: Date.now() });
+    }
+
+    return text;
+  }
+
+  private readBody(req: http.IncomingMessage): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+      req.on("error", reject);
+    });
+  }
+
+  private handleRequest = async (
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ): Promise<void> => {
+    const sendJson = (status: number, data: unknown) => {
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(data));
+    };
+
+    const url = req.url ?? "/";
+    const method = req.method ?? "GET";
+
+    if (url === "/health" && method === "GET") {
+      sendJson(200, { ok: true, sessions: this.sessions.size });
+      return;
+    }
+
+    if (url === "/chat" && method === "POST") {
+      try {
+        const body = await this.readBody(req);
+        const { sessionId, messages } = JSON.parse(body) as {
+          sessionId: string;
+          messages: Array<{ role: string; content: string }>;
+        };
+        if (!sessionId || !Array.isArray(messages)) {
+          sendJson(400, { error: "Missing sessionId or messages" });
+          return;
+        }
+        const text = await this.processChat(sessionId, messages);
+        sendJson(200, { response: text });
+      } catch (err) {
+        logger.error("Worker chat error", err);
+        sendJson(500, { error: err instanceof Error ? err.message : String(err) });
+      }
+      return;
+    }
+
+    sendJson(404, { error: "Not found" });
+  };
+
+  private startServer(): Promise<void> {
+    if (this.startPromise) return this.startPromise;
+
+    this.startPromise = new Promise<void>((resolve, reject) => {
+      const tryPort = (port: number) => {
+        const srv = http.createServer(this.handleRequest);
+
+        srv.listen(port, "127.0.0.1", () => {
+          this.server = srv;
+          this.port = port;
+          this.backoffMs = 1_000;
+          logger.info(`Claude Code Worker listening on 127.0.0.1:${port}`);
+          resolve();
+        });
+
+        srv.on("error", (err: NodeJS.ErrnoException) => {
+          if (err.code === "EADDRINUSE") {
+            tryPort(port + 1);
+          } else {
+            this.startPromise = null;
+            reject(err);
+          }
+        });
+      };
+
+      tryPort(WORKER_PORT_BASE);
+    });
+
+    return this.startPromise;
+  }
+
+  private isHealthy(): Promise<boolean> {
+    if (!this.port) return Promise.resolve(false);
+    return new Promise<boolean>((resolve) => {
+      const req = http.request(
+        { hostname: "127.0.0.1", port: this.port!, path: "/health", method: "GET" },
+        (res) => {
+          res.resume();
+          resolve(res.statusCode === 200);
+        }
+      );
+      req.on("error", () => resolve(false));
+      req.setTimeout(CONNECT_TIMEOUT_MS, () => {
+        req.destroy();
+        resolve(false);
+      });
+      req.end();
+    });
+  }
+
+  private async ensureRunning(): Promise<void> {
+    if (this.server && this.port) {
+      const ok = await this.isHealthy();
+      if (ok) return;
+      // Server has died — reset state and restart with exponential backoff
+      this.server = null;
+      this.port = null;
+      this.startPromise = null;
+      await new Promise<void>((r) => setTimeout(r, this.backoffMs));
+      this.backoffMs = Math.min(this.backoffMs * 2, MAX_BACKOFF_MS);
+    }
+    await this.startServer();
+  }
+
+  async send(
+    sessionId: string,
+    messages: Array<{ role: string; content: string }>
+  ): Promise<string> {
+    await this.ensureRunning();
+
+    const port = this.port!;
+    const body = JSON.stringify({ sessionId, messages });
+
+    return new Promise<string>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path: "/chat",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(body),
+          },
+        },
+        (res) => {
+          let data = "";
+          res.on("data", (c: Buffer) => (data += c.toString()));
+          res.on("end", () => {
+            try {
+              const parsed = JSON.parse(data) as { response?: string; error?: string };
+              if (parsed.error) reject(new Error(parsed.error));
+              else resolve(parsed.response ?? "");
+            } catch (e) {
+              reject(e);
+            }
+          });
+        }
+      );
+
+      req.on("error", reject);
+      req.setTimeout(CLAUDE_CLI_TIMEOUT_MS + CONNECT_TIMEOUT_MS, () => {
+        req.destroy(new Error("Worker request timed out"));
+      });
+      req.write(body);
+      req.end();
+    });
+  }
+
+  stop(): void {
+    if (this.server) {
+      this.server.close();
+      this.server = null;
+      this.port = null;
+      this.startPromise = null;
+    }
+    this.sessions.clear();
+    logger.info("Claude Code Worker stopped");
+  }
+}
+
+export const claudeCodeWorker = new ClaudeCodeWorker();

--- a/src/main/handlers/systemCommandHandler.ts
+++ b/src/main/handlers/systemCommandHandler.ts
@@ -21,7 +21,13 @@ export class SystemCommandHandler {
     const command = substituteVariables(step.command);
     const cwd = step.cwd ? substituteVariables(step.cwd) : undefined;
     const timeout = Math.min(Math.max(1000, Number(step.timeout ?? 30_000)), MAX_TIMEOUT);
-    const shell = step.shell ? substituteVariables(step.shell) : undefined;
+    const defaultShell =
+      process.platform === "win32"
+        ? "powershell.exe"
+        : process.platform === "darwin"
+          ? "/bin/zsh"
+          : "/bin/bash";
+    const shell = step.shell ? substituteVariables(step.shell) : defaultShell;
     const failOnNonZero = step.failOnNonZero !== false;
 
     debugLogger.debug("SystemCommand", "Executing command", { command, cwd, timeout });

--- a/src/main/ipcHandlers.ts
+++ b/src/main/ipcHandlers.ts
@@ -622,6 +622,7 @@ export function registerIPCHandlers(
         apiKey?: string;
         model?: string;
         baseUrl?: string;
+        sessionId?: string;
       }
     ) => {
       return callLLM(params);
@@ -922,20 +923,22 @@ export function registerIPCHandlers(
     async (_event, params: { command: string; cwd?: string; timeout?: number }) => {
       const { exec: execCmd } = await import("child_process");
       const timeout = Math.min(Math.max(1000, params.timeout || 30000), 300000);
+      const shell =
+        process.platform === "win32"
+          ? "powershell.exe"
+          : process.platform === "darwin"
+            ? "/bin/zsh"
+            : "/bin/bash";
       return new Promise((resolve) => {
-        execCmd(
-          params.command,
-          { cwd: params.cwd, timeout, shell: "/bin/bash" },
-          (error, stdout, stderr) => {
-            const exitCode = error ? ((error as unknown as { code?: number }).code ?? 1) : 0;
-            resolve({
-              success: !error,
-              stdout: stdout?.toString() || "",
-              stderr: stderr?.toString() || "",
-              exitCode,
-            });
-          }
-        );
+        execCmd(params.command, { cwd: params.cwd, timeout, shell }, (error, stdout, stderr) => {
+          const exitCode = error ? ((error as unknown as { code?: number }).code ?? 1) : 0;
+          resolve({
+            success: !error,
+            stdout: stdout?.toString() || "",
+            stderr: stderr?.toString() || "",
+            exitCode,
+          });
+        });
       });
     }
   );

--- a/src/main/llmClient.ts
+++ b/src/main/llmClient.ts
@@ -1,7 +1,7 @@
+import { claudeCodeWorker } from "@main/claudeCodeWorker";
 import { getCredential } from "@main/credentialsStore";
 import { createLogger } from "@utils/logger";
 import axios from "axios";
-import { execSync } from "child_process";
 
 const logger = createLogger("LLMClient");
 
@@ -12,6 +12,7 @@ export interface LLMParams {
   apiKey?: string;
   model?: string;
   baseUrl?: string;
+  sessionId?: string;
 }
 
 export interface LLMResult {
@@ -86,101 +87,8 @@ export async function callLLM(params: LLMParams): Promise<LLMResult> {
       const content = res.data.content;
       response = Array.isArray(content) && content.length > 0 ? content[0].text || "" : "";
     } else if (params.provider === "claude-code") {
-      const lastUserMsg = [...params.messages].reverse().find((m) => m.role === "user");
-      if (!lastUserMsg) throw new Error("No user message found");
-
-      const systemMsgs = params.messages.filter((m) => m.role === "system");
-      const contextParts: string[] = [];
-      if (systemMsgs.length > 0) {
-        contextParts.push(systemMsgs.map((m) => m.content).join("\n"));
-      }
-      const recentMsgs = params.messages.filter((m) => m.role !== "system").slice(-10);
-      if (recentMsgs.length > 1) {
-        const history = recentMsgs
-          .slice(0, -1)
-          .map((m) => `${m.role === "user" ? "Human" : "Assistant"}: ${m.content}`)
-          .join("\n\n");
-        contextParts.push("Previous conversation:\n" + history);
-      }
-      contextParts.push(lastUserMsg.content);
-      const fullPrompt = contextParts.join("\n\n");
-
-      const { spawn: spawnProc } = await import("child_process");
-      const isWindows = process.platform === "win32";
-      let claudePath = isWindows ? "claude.cmd" : "claude";
-      try {
-        const whichCmd = isWindows ? "where claude" : "which claude";
-        claudePath = execSync(whichCmd, { encoding: "utf-8" }).trim().split(/\r?\n/)[0];
-      } catch {
-        const { existsSync } = await import("fs");
-        const candidates = isWindows
-          ? [
-              `${process.env.APPDATA}\\npm\\claude.cmd`,
-              `${process.env.APPDATA}\\npm\\claude`,
-              `${process.env.LOCALAPPDATA}\\npm\\claude.cmd`,
-            ]
-          : [
-              `${process.env.HOME}/.local/bin/claude`,
-              "/usr/local/bin/claude",
-              `${process.env.HOME}/.npm-global/bin/claude`,
-            ];
-        for (const c of candidates) {
-          if (existsSync(c)) {
-            claudePath = c;
-            break;
-          }
-        }
-      }
-      const userShellEnv = { ...process.env };
-      delete userShellEnv.ANTHROPIC_API_KEY;
-      if (!isWindows && !userShellEnv.PATH?.includes(".local/bin")) {
-        userShellEnv.PATH = `${process.env.HOME}/.local/bin:${userShellEnv.PATH}`;
-      }
-
-      response = await new Promise<string>((resolve, reject) => {
-        const CLAUDE_CLI_TIMEOUT_MS = 600000;
-        let timedOut = false;
-        const proc = spawnProc(claudePath, ["-p"], {
-          stdio: ["pipe", "pipe", "pipe"],
-          env: userShellEnv,
-        });
-        const timer = setTimeout(() => {
-          timedOut = true;
-          proc.kill("SIGTERM");
-        }, CLAUDE_CLI_TIMEOUT_MS);
-        let stdout = "";
-        let stderr = "";
-        proc.stdout.on("data", (d: Buffer) => (stdout += d.toString()));
-        proc.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
-        proc.on("error", (err) => {
-          clearTimeout(timer);
-          reject(new Error(err.message));
-        });
-        proc.on("close", (code) => {
-          clearTimeout(timer);
-          if (timedOut) {
-            logger.error("claude CLI timed out", {
-              timeoutMs: CLAUDE_CLI_TIMEOUT_MS,
-              stdout,
-              stderr,
-            });
-            reject(
-              new Error(
-                `Claude CLI did not respond within ${Math.round(CLAUDE_CLI_TIMEOUT_MS / 1000)}s. Try a shorter prompt, or switch providers in Settings.`
-              )
-            );
-            return;
-          }
-          if (code !== 0) {
-            logger.error("claude CLI failed", { code, stdout, stderr });
-            reject(new Error(stderr.trim() || stdout.trim() || `claude exited with code ${code}`));
-          } else {
-            resolve(stdout.trim());
-          }
-        });
-        proc.stdin.write(fullPrompt);
-        proc.stdin.end();
-      });
+      const sessionId = params.sessionId ?? `app-auto-${Date.now()}`;
+      response = await claudeCodeWorker.send(sessionId, params.messages);
     } else {
       // Ollama
       const baseUrl = (params.baseUrl || "http://localhost:11434").replace(/\/+$/, "");

--- a/src/main/telegramBot.ts
+++ b/src/main/telegramBot.ts
@@ -1,3 +1,4 @@
+import { buildPlatformShellNote } from "@utils/platformPrompt";
 import { exec } from "child_process";
 import TelegramBot from "node-telegram-bot-api";
 import type { AgentManager } from "./agentManager";
@@ -37,23 +38,7 @@ interface BotConfig {
 // ─── System prompt ────────────────────────────────────────────────────────────
 
 function buildSystemPrompt(): string {
-  const isWindows = process.platform === "win32";
-  const shellNote = isWindows
-    ? `## Platform: Windows — PowerShell
-run-command uses PowerShell. Use PowerShell syntax only.
-- ALWAYS write files to $env:TEMP or $env:APPDATA — NEVER to C:\\ (access denied)
-- Write a script: \`Set-Content "$env:TEMP\\\\loopi-script.ps1" 'your script'\`
-- Run a script: \`powershell -ExecutionPolicy Bypass -File "$env:TEMP\\\\loopi-script.ps1"\`
-- Windows notification: \`Add-Type -AssemblyName System.Windows.Forms; $n = New-Object System.Windows.Forms.NotifyIcon; $n.Icon = [System.Drawing.SystemIcons]::Information; $n.Visible = $true; $n.ShowBalloonTip(5000,'Loopi','{{message}}',[System.Windows.Forms.ToolTipIcon]::Info)\`
-- Schedule task: \`schtasks /create /tn "TaskName" /tr "powershell -File $env:TEMP\\\\script.ps1" /sc MINUTE /mo 5 /f\`
-- Read file: \`Get-Content "$env:TEMP\\\\data.txt"\`
-- Delete scheduled task: \`schtasks /delete /tn "TaskName" /f\`
-`
-    : `## Platform: Linux/macOS — /bin/sh
-run-command uses /bin/sh.
-- Notifications: \`notify-send "Title" "Body"\` (Linux) or \`osascript -e 'display notification "Body" with title "Title"'\` (macOS)
-- Schedule: use cron via \`crontab -e\`
-`;
+  const shellNote = buildPlatformShellNote(process.platform);
 
   return `You are Loopi AI, accessible via Telegram. You have FULL capabilities — create workflows, run commands, build automations. Users message from their phone but you execute real actions on their computer.
 
@@ -182,7 +167,12 @@ function stepsToAutomation(wfConfig: Record<string, unknown>) {
 
 function runCommand(command: string): Promise<string> {
   return new Promise((resolve) => {
-    const shell = process.platform === "win32" ? "powershell.exe" : "/bin/sh";
+    const shell =
+      process.platform === "win32"
+        ? "powershell.exe"
+        : process.platform === "darwin"
+          ? "/bin/zsh"
+          : "/bin/bash";
     exec(command, { timeout: 30000, shell }, (_err, stdout, stderr) => {
       const out = stdout?.trim();
       const err = stderr?.trim();

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -210,6 +210,7 @@ export interface ElectronAPI {
       apiKey?: string;
       model?: string;
       baseUrl?: string;
+      sessionId?: string;
     }) => Promise<{
       success: boolean;
       response?: string;

--- a/src/utils/platformPrompt.ts
+++ b/src/utils/platformPrompt.ts
@@ -1,0 +1,48 @@
+/**
+ * Returns the OS-specific shell/command section injected into every AI system prompt.
+ * Keeps Chat, Telegram, and any future entrypoint in sync automatically.
+ *
+ * @param platform - Node's process.platform value ("win32" | "darwin" | "linux" | ...)
+ */
+export function buildPlatformShellNote(platform: string): string {
+  if (platform === "win32") {
+    return `## Platform: Windows
+run-command uses PowerShell. Write native PowerShell — do NOT wrap in \`powershell -command "..."\`.
+- Open apps: \`Start-Process notepad\`, \`Start-Process calc\`
+- Create dirs: \`New-Item -ItemType Directory -Force "$env:USERPROFILE\\Desktop\\MyFolder"\`
+- Write files: \`Set-Content "$env:TEMP\\file.txt" "content"\`
+- Read files: \`Get-Content "$env:TEMP\\file.txt"\`
+- User paths: \`$env:USERPROFILE\`, \`$env:APPDATA\`, \`$env:TEMP\` — never hardcode \`C:\\Users\\...\`
+- Screenshots: prefer the \`desktopScreenshot\` workflow step; for run-command use:
+  \`Add-Type -AssemblyName System.Windows.Forms,System.Drawing; $s=[System.Windows.Forms.Screen]::PrimaryScreen; $b=New-Object System.Drawing.Bitmap($s.Bounds.Width,$s.Bounds.Height); $g=[System.Drawing.Graphics]::FromImage($b); $g.CopyFromScreen($s.Bounds.Location,[System.Drawing.Point]::Empty,$s.Bounds.Size); $b.Save("$env:USERPROFILE\\Desktop\\screenshot.png"); $g.Dispose(); $b.Dispose()\`
+- Notifications: \`Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(5000,'Loopi','Message',[System.Windows.Forms.ToolTipIcon]::Info)\`
+- Schedule: \`schtasks /create /tn "TaskName" /tr "powershell -File $env:TEMP\\script.ps1" /sc MINUTE /mo 5 /f\`
+- ALWAYS write scripts/data to \`$env:TEMP\` or \`$env:APPDATA\` — never to \`C:\\\` root (access denied)
+- Chain commands with \`;\` or use separate run-command blocks`;
+  }
+
+  if (platform === "darwin") {
+    return `## Platform: macOS
+run-command uses /bin/zsh.
+- Open apps: \`open -a "App Name"\`, \`open ~/Desktop/file.txt\`, \`open https://example.com\`
+- Screenshots: \`screencapture ~/Desktop/screenshot.png\` (built-in, no extra tools needed)
+- Notifications: \`osascript -e 'display notification "Body" with title "Title"'\`
+- Create dirs: \`mkdir -p ~/path/to/dir\`
+- Write files: \`echo "content" > ~/Desktop/file.txt\`
+- Schedule: cron via \`crontab -e\` or launchd plists in ~/Library/LaunchAgents/
+- User paths: \`$HOME\`, \`~/Desktop\`, \`~/Documents\`, \`~/Library\`
+- Chain commands: \`&&\` or \`;\` or separate run-command blocks`;
+  }
+
+  // Linux (and any other Unix-like platform)
+  return `## Platform: Linux
+run-command uses /bin/bash.
+- Open files/URLs: \`xdg-open file\` or \`xdg-open https://example.com\`
+- Screenshots: \`scrot ~/Desktop/screenshot.png\` or \`gnome-screenshot -f ~/Desktop/shot.png\` or \`import -window root ~/Desktop/screenshot.png\`
+- Notifications: \`notify-send "Title" "Body"\`
+- Create dirs: \`mkdir -p ~/path/to/dir\`
+- Write files: \`echo "content" > ~/Desktop/file.txt\`
+- Schedule: cron via \`crontab -e\`
+- User paths: \`$HOME\`, \`~/Desktop\`, \`~/Documents\`
+- Chain commands: \`&&\` or \`;\` or separate run-command blocks`;
+}


### PR DESCRIPTION
## Summary

  - **Windows shell fix** — system:exec and systemCommandHandler now use powershell.exe on Windows, /bin/zsh on macOS, /bin/bash on Linux. Previously hardcoded to /bin/bash which
  fell back to cmd.exe on Windows, mangling quotes in any PowerShell command (the Add-Type -AssemblyName System.Windows.F truncation bug)
  - **OS-aware AI prompts** — extracted buildPlatformShellNote(platform) shared util (src/utils/platformPrompt.ts) so Chat and Telegram bot stay in sync. Each OS now gets its own
  shell and correct examples — screencapture on macOS, notify-send on Linux, PowerShell screenshot snippet on Windows
  - **Claude Code persistent sessions** — replaced per-request subprocess spawning in llmClient.ts with a persistent ClaudeCodeWorker (src/main/claudeCodeWorker.ts). Worker runs
  an HTTP server on loopback (port 19544+), maps app session IDs to Claude CLI session_id values, and uses --resume on subsequent turns so conversation history is owned by
  the CLI — no manual prompt reconstruction. Lazy-starts on first request, reconnects with 1s→30s exponential backoff
  - **Instant dashboard refresh** — Chat.tsx dispatches loopi:workflowSaved and loopi:agentCreated DOM events after creation. app.tsx and AgentsPanel listen and reload
  immediately — no restart needed. Also fixed the Telegram agentCreated handler which showed a toast but never reloaded the agents list
